### PR TITLE
Fix inheritance of parentless group

### DIFF
--- a/example/01-simple/main.cpp
+++ b/example/01-simple/main.cpp
@@ -48,7 +48,7 @@ groups:
 std::shared_ptr<soralog::Configurator> cascade_configurator = [] {
   auto prev = std::make_shared<soralog::ConfiguratorFromYAML>(std::string(R"(
 groups:
-  - name: main
+  - name: 3rd_party
     level: info
     children:
       - name: first-1
@@ -57,6 +57,7 @@ groups:
           - name: second-1-2
             children:
               - name: third-1-2-1
+                level: critical
           - name: second-1-3
       - name: first-2
         children:
@@ -76,6 +77,8 @@ groups:
   - name: main
     sink: console
     level: trace
+    children:
+      - name: 3rd_party
   )"));
 }();
 

--- a/include/soralog/group.hpp
+++ b/include/soralog/group.hpp
@@ -51,11 +51,11 @@ namespace soralog {
     }
 
     /**
-     * @returns true if level is overriden, and true if it is inherited from
+     * @returns true if level is overridden, and true if it is inherited from
      * group
      */
-    [[nodiscard]] bool hasLevelOverriden() const noexcept {
-      return has_level_overriden_;
+    [[nodiscard]] bool hasLevelOverridden() const noexcept {
+      return has_level_overridden_;
     }
 
     /**
@@ -64,7 +64,7 @@ namespace soralog {
     void resetLevel();
 
     /**
-     * Set level to {@param level}. Level will be marked as overriden
+     * Set level to {@param level}. Level will be marked as overridden
      */
     void setLevel(Level level);
 
@@ -88,11 +88,11 @@ namespace soralog {
     }
 
     /**
-     * @returns true if sink is overriden, and true if it is inherited from
+     * @returns true if sink is overridden, and true if it is inherited from
      * group
      */
-    [[nodiscard]] bool hasSinkOverriden() const noexcept {
-      return has_sink_overriden_;
+    [[nodiscard]] bool hasSinkOverridden() const noexcept {
+      return has_sink_overridden_;
     }
 
     /**
@@ -102,12 +102,12 @@ namespace soralog {
 
     /**
      * Set sink to sink with name {@param sink_name}.
-     * Level will be marked as overriden
+     * Level will be marked as overridden
      */
     void setSink(const std::string &sink_name);
 
     /**
-     * Set sink to sink {@param sink}. Level will be marked as overriden
+     * Set sink to sink {@param sink}. Level will be marked as overridden
      */
     void setSink(std::shared_ptr<const Sink> sink);
 
@@ -132,20 +132,20 @@ namespace soralog {
 
     /**
      * Unset parent group.
-     * All properties will be marked as overriden
+     * All properties will be marked as overridden
      */
 
     void unsetParentGroup();
 
     /**
      * Set parent group to {@param group}.
-     * Non overriden properties will be inherited from new parent
+     * Non overridden properties will be inherited from new parent
      */
     void setParentGroup(std::shared_ptr<const Group> group);
 
     /**
      * Set parent group to group with name {@param group_name}.
-     * Non overriden properties will be inherited from new parent
+     * Non overridden properties will be inherited from new parent
      */
     void setParentGroup(const std::string &group_name);
 
@@ -156,10 +156,10 @@ namespace soralog {
     std::shared_ptr<const Group> parent_group_;
 
     std::shared_ptr<const Sink> sink_;
-    bool has_sink_overriden_{};
+    bool has_sink_overridden_{};
 
     Level level_{};
-    bool has_level_overriden_{};
+    bool has_level_overridden_{};
   };
 
 }  // namespace soralog

--- a/include/soralog/group.hpp
+++ b/include/soralog/group.hpp
@@ -54,8 +54,8 @@ namespace soralog {
      * @returns true if level is overridden, and true if it is inherited from
      * group
      */
-    [[nodiscard]] bool hasLevelOverridden() const noexcept {
-      return has_level_overridden_;
+    [[nodiscard]] bool isLevelOverridden() const noexcept {
+      return is_level_overridden_;
     }
 
     /**
@@ -91,8 +91,8 @@ namespace soralog {
      * @returns true if sink is overridden, and true if it is inherited from
      * group
      */
-    [[nodiscard]] bool hasSinkOverridden() const noexcept {
-      return has_sink_overridden_;
+    [[nodiscard]] bool isSinkOverridden() const noexcept {
+      return is_sink_overridden_;
     }
 
     /**
@@ -156,10 +156,10 @@ namespace soralog {
     std::shared_ptr<const Group> parent_group_;
 
     std::shared_ptr<const Sink> sink_;
-    bool has_sink_overridden_{};
+    bool is_sink_overridden_{};
 
     Level level_{};
-    bool has_level_overridden_{};
+    bool is_level_overridden_{};
   };
 
 }  // namespace soralog

--- a/include/soralog/logger.hpp
+++ b/include/soralog/logger.hpp
@@ -195,8 +195,8 @@ namespace soralog {
      * @returns true if level is overridden, and true if it is inherited from
      * group
      */
-    [[nodiscard]] bool hasLevelOverridden() const noexcept {
-      return has_level_overridden_;
+    [[nodiscard]] bool isLevelOverridden() const noexcept {
+      return is_level_overridden_;
     }
 
     /**
@@ -232,8 +232,8 @@ namespace soralog {
      * @returns true if sink is overridden, and true if it is inherited from
      * group
      */
-    [[nodiscard]] bool hasSinkOverridden() const noexcept {
-      return has_sink_overridden_;
+    [[nodiscard]] bool isSinkOverridden() const noexcept {
+      return is_sink_overridden_;
     }
 
     /**
@@ -290,10 +290,10 @@ namespace soralog {
     std::shared_ptr<const Group> group_;
 
     std::shared_ptr<Sink> sink_;
-    bool has_sink_overridden_{};
+    bool is_sink_overridden_{};
 
     Level level_{};
-    bool has_level_overridden_{};
+    bool is_level_overridden_{};
   };
 
 }  // namespace soralog

--- a/include/soralog/logger.hpp
+++ b/include/soralog/logger.hpp
@@ -192,11 +192,11 @@ namespace soralog {
     }
 
     /**
-     * @returns true if level is overriden, and true if it is inherited from
+     * @returns true if level is overridden, and true if it is inherited from
      * group
      */
-    [[nodiscard]] bool hasLevelOverriden() const noexcept {
-      return has_level_overriden_;
+    [[nodiscard]] bool hasLevelOverridden() const noexcept {
+      return has_level_overridden_;
     }
 
     /**
@@ -205,7 +205,7 @@ namespace soralog {
     void resetLevel();
 
     /**
-     * Set level to {@param level}. Level will be marked as overriden
+     * Set level to {@param level}. Level will be marked as overridden
      */
     void setLevel(Level level);
 
@@ -229,11 +229,11 @@ namespace soralog {
     }
 
     /**
-     * @returns true if sink is overriden, and true if it is inherited from
+     * @returns true if sink is overridden, and true if it is inherited from
      * group
      */
-    [[nodiscard]] bool hasSinkOverriden() const noexcept {
-      return has_sink_overriden_;
+    [[nodiscard]] bool hasSinkOverridden() const noexcept {
+      return has_sink_overridden_;
     }
 
     /**
@@ -243,12 +243,12 @@ namespace soralog {
 
     /**
      * Set sink to sink with name {@param sink_name}.
-     * Level will be marked as overriden
+     * Level will be marked as overridden
      */
     void setSink(const std::string &sink_name);
 
     /**
-     * Set sink to sink {@param sink}. Level will be marked as overriden
+     * Set sink to sink {@param sink}. Level will be marked as overridden
      */
     void setSink(std::shared_ptr<Sink> sink);
 
@@ -273,13 +273,13 @@ namespace soralog {
 
     /**
      * Set group to group {@param group}.
-     * Non overriden properties will me inherited from new group
+     * Non overridden properties will me inherited from new group
      */
     void setGroup(std::shared_ptr<const Group> group);
 
     /**
      * Set group to group with name {@param group_name}.
-     * Non overriden properties will me inherited from new group
+     * Non overridden properties will me inherited from new group
      */
     void setGroup(const std::string &group_name);
 
@@ -290,10 +290,10 @@ namespace soralog {
     std::shared_ptr<const Group> group_;
 
     std::shared_ptr<Sink> sink_;
-    bool has_sink_overriden_{};
+    bool has_sink_overridden_{};
 
     Level level_{};
-    bool has_level_overriden_{};
+    bool has_level_overridden_{};
   };
 
 }  // namespace soralog

--- a/include/soralog/logging_system.hpp
+++ b/include/soralog/logging_system.hpp
@@ -56,7 +56,7 @@ namespace soralog {
     /**
      * @returns loggers (with creating that if it isn't exists yet) with
      * name {@param logger_name}, group with name {@param group_name}, and level
-     * overriden to {@param level}
+     * overridden to {@param level}
      */
     [[nodiscard]] std::shared_ptr<Logger> getLogger(
         std::string logger_name, const std::string &group_name,
@@ -68,7 +68,7 @@ namespace soralog {
     /**
      * @returns loggers (with creating that if it isn't exists yet) with
      * name {@param logger_name}, group with name {@param group_name}, and sink
-     * overriden to sink with name {@param sink_name}
+     * overridden to sink with name {@param sink_name}
      */
     [[nodiscard]] std::shared_ptr<Logger> getLogger(
         std::string logger_name, const std::string &group_name,
@@ -80,7 +80,7 @@ namespace soralog {
     /**
      * @returns loggers (with creating that if it isn't exists yet) with
      * name {@param logger_name}, group with name {@param group_name}, and sink
-     * andd level overriden to {@param sink_name} and {@param level}
+     * andd level overridden to {@param sink_name} and {@param level}
      */
     [[nodiscard]] std::shared_ptr<Logger> getLogger(
         std::string logger_name, const std::string &group_name,
@@ -129,14 +129,14 @@ namespace soralog {
                           const std::string &parent);
     /**
      * Unset parent group of group {@param group_name}.
-     * All properties will be marked as overriden (stay his own)
+     * All properties will be marked as overridden (stay his own)
      * @returns true if success
      */
     bool unsetParentOfGroup(const std::string &group_name);
 
     /**
      * Set sink of group {@param group_name} to sink with name {@param
-     * sink_name}. Sink will be marked as overriden
+     * sink_name}. Sink will be marked as overridden
      * @returns true if success
      */
     bool setSinkOfGroup(const std::string &group_name,
@@ -151,7 +151,7 @@ namespace soralog {
 
     /**
      * Set level of group {@param group_name} to level {@param level}. Level
-     * will be marked as overriden
+     * will be marked as overridden
      * @returns true if success
      */
     bool setLevelOfGroup(const std::string &group_name, Level level);
@@ -173,7 +173,7 @@ namespace soralog {
 
     /**
      * Set sink of logger {@param logger_name} to sink with name {@param
-     * group_name}. Sink will be marked as overriden.
+     * group_name}. Sink will be marked as overridden.
      * @returns true if success
      */
     bool setSinkOfLogger(const std::string &logger_name,
@@ -188,7 +188,7 @@ namespace soralog {
 
     /**
      * Set sink of logger {@param logger_name} to sink with name {@param
-     * group_name}. Sink will be marked as overriden.
+     * group_name}. Sink will be marked as overridden.
      * @returns true if success
      */
     bool setLevelOfLogger(const std::string &logger_name, Level level);

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -41,18 +41,20 @@ namespace soralog {
   void Group::resetLevel() {
     if (parent_group_) {
       level_ = parent_group_->level();
-      has_level_overriden_ = false;
+      has_level_overridden_ = false;
     }
   }
 
   void Group::setLevel(Level level) {
-    has_level_overriden_ = true;
+    if (parent_group_) {
+      has_level_overridden_ = true;
+    }
     level_ = level;
   }
 
   void Group::setLevelFromGroup(const std::shared_ptr<const Group> &group) {
     assert(group);
-    has_level_overriden_ = group != parent_group_;
+    has_level_overridden_ = group != parent_group_;
     level_ = group->level();
   }
 
@@ -67,13 +69,15 @@ namespace soralog {
   void Group::resetSink() {
     if (parent_group_) {
       sink_ = parent_group_->sink();
-      has_sink_overriden_ = false;
+      has_sink_overridden_ = false;
     }
   }
 
   void Group::setSink(std::shared_ptr<const Sink> sink) {
     assert(sink);
-    has_sink_overriden_ = true;
+    if (parent_group_) {
+      has_sink_overridden_ = true;
+    }
     sink_ = std::move(sink);
   }
 
@@ -85,7 +89,7 @@ namespace soralog {
 
   void Group::setSinkFromGroup(const std::shared_ptr<const Group> &group) {
     assert(group);
-    has_sink_overriden_ = group != parent_group_;
+    has_sink_overridden_ = group != parent_group_;
     sink_ = group->sink();
   }
 
@@ -99,22 +103,17 @@ namespace soralog {
 
   void Group::unsetParentGroup() {
     parent_group_.reset();
-    has_level_overriden_ = true;
-    has_sink_overriden_ = true;
   }
 
   void Group::setParentGroup(std::shared_ptr<const Group> group) {
     parent_group_ = std::move(group);
     if (parent_group_) {
-      if (not has_sink_overriden_) {
+      if (not has_sink_overridden_) {
         setSinkFromGroup(parent_group_);
       }
-      if (not has_level_overriden_) {
+      if (not has_level_overridden_) {
         setLevelFromGroup(parent_group_);
       }
-    } else {
-      has_sink_overriden_ = true;
-      has_level_overriden_ = true;
     }
   }
 

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -41,20 +41,20 @@ namespace soralog {
   void Group::resetLevel() {
     if (parent_group_) {
       level_ = parent_group_->level();
-      has_level_overridden_ = false;
+      is_level_overridden_ = false;
     }
   }
 
   void Group::setLevel(Level level) {
     if (parent_group_) {
-      has_level_overridden_ = true;
+      is_level_overridden_ = true;
     }
     level_ = level;
   }
 
   void Group::setLevelFromGroup(const std::shared_ptr<const Group> &group) {
     assert(group);
-    has_level_overridden_ = group != parent_group_;
+    is_level_overridden_ = group != parent_group_;
     level_ = group->level();
   }
 
@@ -69,14 +69,14 @@ namespace soralog {
   void Group::resetSink() {
     if (parent_group_) {
       sink_ = parent_group_->sink();
-      has_sink_overridden_ = false;
+      is_sink_overridden_ = false;
     }
   }
 
   void Group::setSink(std::shared_ptr<const Sink> sink) {
     assert(sink);
     if (parent_group_) {
-      has_sink_overridden_ = true;
+      is_sink_overridden_ = true;
     }
     sink_ = std::move(sink);
   }
@@ -89,7 +89,7 @@ namespace soralog {
 
   void Group::setSinkFromGroup(const std::shared_ptr<const Group> &group) {
     assert(group);
-    has_sink_overridden_ = group != parent_group_;
+    is_sink_overridden_ = group != parent_group_;
     sink_ = group->sink();
   }
 
@@ -108,10 +108,10 @@ namespace soralog {
   void Group::setParentGroup(std::shared_ptr<const Group> group) {
     parent_group_ = std::move(group);
     if (parent_group_) {
-      if (not has_sink_overridden_) {
+      if (not is_sink_overridden_) {
         setSinkFromGroup(parent_group_);
       }
-      if (not has_level_overridden_) {
+      if (not is_level_overridden_) {
         setLevelFromGroup(parent_group_);
       }
     }

--- a/src/impl/configurator_from_yaml.cpp
+++ b/src/impl/configurator_from_yaml.cpp
@@ -32,10 +32,7 @@ namespace soralog {
     ConfiguratorFromYAML::Result result;
 
     if (previous_ != nullptr) {
-      auto prev_result = previous_->applyOn(system_);
-      result.has_error = result.has_error || prev_result.has_error;
-      result.has_warning = result.has_warning || prev_result.has_warning;
-      result.message += prev_result.message;
+      result = previous_->applyOn(system_);
     }
 
     YAML::Node node;
@@ -242,7 +239,7 @@ namespace soralog {
 
     if (system_.getSink(name)) {
       errors_ << "W: Already exists sink with name '" << name
-              << "'; Previous version will be overriden\n";
+              << "'; Previous version will be overridden\n";
       has_warning_ = true;
     }
 
@@ -307,7 +304,7 @@ namespace soralog {
 
     if (system_.getSink(name)) {
       errors_ << "W: Already exists sink with name '" << name
-              << "'; Previous version will be overriden\n";
+              << "'; Previous version will be overridden\n";
       has_warning_ = true;
     }
 

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -27,13 +27,13 @@ namespace soralog {
   }
 
   void Logger::setLevel(Level level) {
-    has_level_overriden_ = true;
+    has_level_overridden_ = true;
     level_ = level;
   }
 
   void Logger::setLevelFromGroup(const std::shared_ptr<const Group> &group) {
     assert(group);
-    has_level_overriden_ = group != group_;
+    has_level_overridden_ = group != group_;
     level_ = group->level();
   }
 
@@ -47,7 +47,7 @@ namespace soralog {
 
   void Logger::resetSink() {
     sink_ = std::const_pointer_cast<Sink>(group_->sink());
-    has_sink_overriden_ = false;
+    has_sink_overridden_ = false;
   }
 
   void Logger::setSink(const std::string &sink_name) {
@@ -58,14 +58,14 @@ namespace soralog {
 
   void Logger::setSink(std::shared_ptr<Sink> sink) {
     assert(sink);
-    has_sink_overriden_ = true;
+    has_sink_overridden_ = true;
     sink_ = std::move(sink);
   }
 
   void Logger::setSinkFromGroup(const std::shared_ptr<const Group> &group) {
     assert(group);
     if (auto sink = std::const_pointer_cast<Sink>(group->sink())) {
-      has_sink_overriden_ = group != group_;
+      has_sink_overridden_ = group != group_;
       sink_ = std::move(sink);
     }
   }
@@ -81,10 +81,10 @@ namespace soralog {
   void Logger::setGroup(std::shared_ptr<const Group> group) {
     assert(group);
     group_ = std::move(group);
-    if (not has_sink_overriden_) {
+    if (not has_sink_overridden_) {
       setSinkFromGroup(group_);
     }
-    if (not has_level_overriden_) {
+    if (not has_level_overridden_) {
       setLevelFromGroup(group_);
     }
   }

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -27,13 +27,13 @@ namespace soralog {
   }
 
   void Logger::setLevel(Level level) {
-    has_level_overridden_ = true;
+    is_level_overridden_ = true;
     level_ = level;
   }
 
   void Logger::setLevelFromGroup(const std::shared_ptr<const Group> &group) {
     assert(group);
-    has_level_overridden_ = group != group_;
+    is_level_overridden_ = group != group_;
     level_ = group->level();
   }
 
@@ -47,7 +47,7 @@ namespace soralog {
 
   void Logger::resetSink() {
     sink_ = std::const_pointer_cast<Sink>(group_->sink());
-    has_sink_overridden_ = false;
+    is_sink_overridden_ = false;
   }
 
   void Logger::setSink(const std::string &sink_name) {
@@ -58,14 +58,14 @@ namespace soralog {
 
   void Logger::setSink(std::shared_ptr<Sink> sink) {
     assert(sink);
-    has_sink_overridden_ = true;
+    is_sink_overridden_ = true;
     sink_ = std::move(sink);
   }
 
   void Logger::setSinkFromGroup(const std::shared_ptr<const Group> &group) {
     assert(group);
     if (auto sink = std::const_pointer_cast<Sink>(group->sink())) {
-      has_sink_overridden_ = group != group_;
+      is_sink_overridden_ = group != group_;
       sink_ = std::move(sink);
     }
   }
@@ -81,10 +81,10 @@ namespace soralog {
   void Logger::setGroup(std::shared_ptr<const Group> group) {
     assert(group);
     group_ = std::move(group);
-    if (not has_sink_overridden_) {
+    if (not is_sink_overridden_) {
       setSinkFromGroup(group_);
     }
-    if (not has_level_overridden_) {
+    if (not is_level_overridden_) {
       setLevelFromGroup(group_);
     }
   }

--- a/src/logging_system.cpp
+++ b/src/logging_system.cpp
@@ -121,6 +121,9 @@ namespace soralog {
                                        const std::shared_ptr<Group> &parent) {
     assert(group != nullptr);
 
+    if (parent && parent->parent() == group) {
+      parent->unsetParentGroup();
+    }
     group->setParentGroup(parent);
 
     std::map<std::shared_ptr<const Group>, int> passed_groups;
@@ -135,7 +138,7 @@ namespace soralog {
       if (current == group) {
         return 0;
       }
-      if (current->hasLevelOverriden() && current->hasSinkOverriden()) {
+      if (current->hasLevelOverridden() && current->hasSinkOverridden()) {
         return -1;
       }
       if (not current->parent()) {
@@ -201,7 +204,7 @@ namespace soralog {
       if (current == group) {
         return 0;
       }
-      if (current->hasSinkOverriden()) {
+      if (current->hasSinkOverridden()) {
         return -1;
       }
       if (not current->parent()) {
@@ -231,7 +234,7 @@ namespace soralog {
 
     for (auto it = loggers_.begin(); it != loggers_.end();) {
       if (auto logger = it->second.lock()) {
-        if (not logger->hasSinkOverriden()) {
+        if (not logger->hasSinkOverridden()) {
           if (auto it2 = passed_groups.find(logger->group());
               it2 != passed_groups.end()) {
             if (it2->second != -1) {
@@ -268,7 +271,7 @@ namespace soralog {
       if (current == group) {
         return 0;
       }
-      if (current->hasLevelOverriden()) {
+      if (current->hasLevelOverridden()) {
         return -1;
       }
       if (not current->parent()) {
@@ -298,7 +301,7 @@ namespace soralog {
 
     for (auto it = loggers_.begin(); it != loggers_.end();) {
       if (auto logger = it->second.lock()) {
-        if (not logger->hasLevelOverriden()) {
+        if (not logger->hasLevelOverridden()) {
           if (auto it2 = passed_groups.find(logger->group());
               it2 != passed_groups.end()) {
             if (it2->second != -1) {
@@ -351,11 +354,13 @@ namespace soralog {
     auto &parent = it2->second;
 
     // Check for recursion
-    for (auto current = parent->parent(); current != nullptr;
-         current = current->parent()) {
-      if (current == group) {
-        // Cyclic parentness is detected
-        return false;
+    if (parent->parent() != group) {
+      for (auto current = parent->parent(); current!=nullptr;
+           current = current->parent()) {
+        if (current==group) {
+          // Cyclic parentness is detected
+          return false;
+        }
       }
     }
 

--- a/src/logging_system.cpp
+++ b/src/logging_system.cpp
@@ -138,7 +138,7 @@ namespace soralog {
       if (current == group) {
         return 0;
       }
-      if (current->hasLevelOverridden() && current->hasSinkOverridden()) {
+      if (current->isLevelOverridden() && current->isSinkOverridden()) {
         return -1;
       }
       if (not current->parent()) {
@@ -204,7 +204,7 @@ namespace soralog {
       if (current == group) {
         return 0;
       }
-      if (current->hasSinkOverridden()) {
+      if (current->isSinkOverridden()) {
         return -1;
       }
       if (not current->parent()) {
@@ -234,7 +234,7 @@ namespace soralog {
 
     for (auto it = loggers_.begin(); it != loggers_.end();) {
       if (auto logger = it->second.lock()) {
-        if (not logger->hasSinkOverridden()) {
+        if (not logger->isSinkOverridden()) {
           if (auto it2 = passed_groups.find(logger->group());
               it2 != passed_groups.end()) {
             if (it2->second != -1) {
@@ -271,7 +271,7 @@ namespace soralog {
       if (current == group) {
         return 0;
       }
-      if (current->hasLevelOverridden()) {
+      if (current->isLevelOverridden()) {
         return -1;
       }
       if (not current->parent()) {
@@ -301,7 +301,7 @@ namespace soralog {
 
     for (auto it = loggers_.begin(); it != loggers_.end();) {
       if (auto logger = it->second.lock()) {
-        if (not logger->hasLevelOverridden()) {
+        if (not logger->isLevelOverridden()) {
           if (auto it2 = passed_groups.find(logger->group());
               it2 != passed_groups.end()) {
             if (it2->second != -1) {
@@ -355,9 +355,9 @@ namespace soralog {
 
     // Check for recursion
     if (parent->parent() != group) {
-      for (auto current = parent->parent(); current!=nullptr;
+      for (auto current = parent->parent(); current != nullptr;
            current = current->parent()) {
-        if (current==group) {
+        if (current == group) {
           // Cyclic parentness is detected
           return false;
         }

--- a/test/unit/group_test.cpp
+++ b/test/unit/group_test.cpp
@@ -75,23 +75,23 @@ TEST_F(GroupTest, MakeGroup) {
   // If parent isn't set, properties must be provided and not mark as overridden
   EXPECT_TRUE(group1_->parent() == nullptr);
   EXPECT_TRUE(group1_->level() == Level::TRACE);
-  EXPECT_FALSE(group1_->hasLevelOverridden());
+  EXPECT_FALSE(group1_->isLevelOverridden());
   EXPECT_TRUE(group1_->sink() == sink1_);
-  EXPECT_FALSE(group1_->hasSinkOverridden());
+  EXPECT_FALSE(group1_->isSinkOverridden());
 
   // If parent is set and properties aren't provided, then they are inherited
   EXPECT_TRUE(group2_->parent() == group1_);
   EXPECT_TRUE(group2_->level() == Level::TRACE);
-  EXPECT_FALSE(group2_->hasLevelOverridden());
+  EXPECT_FALSE(group2_->isLevelOverridden());
   EXPECT_TRUE(group2_->sink() == sink1_);
-  EXPECT_FALSE(group2_->hasSinkOverridden());
+  EXPECT_FALSE(group2_->isSinkOverridden());
 
   // If parent is set and properties are provided, then they mark as overridden
   EXPECT_TRUE(group3_->parent() == group2_);
   EXPECT_TRUE(group3_->level() == Level::DEBUG);
-  EXPECT_TRUE(group3_->hasLevelOverridden());
+  EXPECT_TRUE(group3_->isLevelOverridden());
   EXPECT_TRUE(group3_->sink() == sink3_);
-  EXPECT_TRUE(group3_->hasSinkOverridden());
+  EXPECT_TRUE(group3_->isSinkOverridden());
 }
 
 TEST_F(GroupTest, ChangeLevel) {
@@ -103,9 +103,9 @@ TEST_F(GroupTest, ChangeLevel) {
   /// @Then level is set and marked as overridden
 
   EXPECT_TRUE(group2_->level() == Level::CRITICAL);
-  EXPECT_TRUE(group2_->hasLevelOverridden());
+  EXPECT_TRUE(group2_->isLevelOverridden());
   EXPECT_TRUE(group3_->level() == Level::INFO);
-  EXPECT_TRUE(group3_->hasLevelOverridden());
+  EXPECT_TRUE(group3_->isLevelOverridden());
 
   /// @When reset level
 
@@ -115,9 +115,9 @@ TEST_F(GroupTest, ChangeLevel) {
   /// @Then level is set from parent group and marked as no overridden
 
   EXPECT_TRUE(group2_->level() == Level::TRACE);
-  EXPECT_FALSE(group2_->hasLevelOverridden());
+  EXPECT_FALSE(group2_->isLevelOverridden());
   EXPECT_TRUE(group3_->level() == Level::TRACE);
-  EXPECT_FALSE(group3_->hasLevelOverridden());
+  EXPECT_FALSE(group3_->isLevelOverridden());
 }
 
 TEST_F(GroupTest, ChangeSink) {
@@ -129,9 +129,9 @@ TEST_F(GroupTest, ChangeSink) {
   /// @Then sink is set to provided and marked as overridden
 
   EXPECT_TRUE(group2_->sink() == sink3_);
-  EXPECT_TRUE(group2_->hasSinkOverridden());
+  EXPECT_TRUE(group2_->isSinkOverridden());
   EXPECT_TRUE(group3_->sink() == sink4_);
-  EXPECT_TRUE(group3_->hasSinkOverridden());
+  EXPECT_TRUE(group3_->isSinkOverridden());
 
   /// @When reset sink
 
@@ -141,9 +141,9 @@ TEST_F(GroupTest, ChangeSink) {
   /// @Then sink is set from parent group and marked as no overridden
 
   EXPECT_TRUE(group2_->sink() == sink1_);
-  EXPECT_FALSE(group2_->hasSinkOverridden());
+  EXPECT_FALSE(group2_->isSinkOverridden());
   EXPECT_TRUE(group3_->sink() == sink1_);
-  EXPECT_FALSE(group3_->hasSinkOverridden());
+  EXPECT_FALSE(group3_->isSinkOverridden());
 }
 
 TEST_F(GroupTest, ChangeGroup) {
@@ -157,15 +157,15 @@ TEST_F(GroupTest, ChangeGroup) {
 
   EXPECT_TRUE(group2_->parent() == group4_);
   EXPECT_TRUE(group2_->level() == Level::VERBOSE);
-  EXPECT_FALSE(group2_->hasLevelOverridden());
+  EXPECT_FALSE(group2_->isLevelOverridden());
   EXPECT_TRUE(group2_->sink() == sink4_);
-  EXPECT_FALSE(group2_->hasSinkOverridden());
+  EXPECT_FALSE(group2_->isSinkOverridden());
 
   EXPECT_TRUE(group3_->parent() == group4_);
   EXPECT_TRUE(group3_->level() == Level::DEBUG);
-  EXPECT_TRUE(group3_->hasLevelOverridden());
+  EXPECT_TRUE(group3_->isLevelOverridden());
   EXPECT_TRUE(group3_->sink() == sink3_);
-  EXPECT_TRUE(group3_->hasSinkOverridden());
+  EXPECT_TRUE(group3_->isSinkOverridden());
 
   /// @When unset parent group
 
@@ -176,13 +176,13 @@ TEST_F(GroupTest, ChangeGroup) {
 
   EXPECT_TRUE(group2_->parent() == nullptr);
   EXPECT_TRUE(group2_->level() == Level::VERBOSE);
-  EXPECT_FALSE(group2_->hasLevelOverridden());
+  EXPECT_FALSE(group2_->isLevelOverridden());
   EXPECT_TRUE(group2_->sink() == sink4_);
-  EXPECT_FALSE(group2_->hasSinkOverridden());
+  EXPECT_FALSE(group2_->isSinkOverridden());
 
   EXPECT_TRUE(group3_->parent() == nullptr);
   EXPECT_TRUE(group3_->level() == Level::DEBUG);
-  EXPECT_TRUE(group3_->hasLevelOverridden());
+  EXPECT_TRUE(group3_->isLevelOverridden());
   EXPECT_TRUE(group3_->sink() == sink3_);
-  EXPECT_TRUE(group3_->hasSinkOverridden());
+  EXPECT_TRUE(group3_->isSinkOverridden());
 }

--- a/test/unit/group_test.cpp
+++ b/test/unit/group_test.cpp
@@ -72,23 +72,26 @@ class GroupTest : public ::testing::Test {
 TEST_F(GroupTest, MakeGroup) {
   /// @Given initial state for all next tests
 
+  // If parent isn't set, properties must be provided and not mark as overridden
   EXPECT_TRUE(group1_->parent() == nullptr);
   EXPECT_TRUE(group1_->level() == Level::TRACE);
-  EXPECT_TRUE(group1_->hasLevelOverriden());
+  EXPECT_FALSE(group1_->hasLevelOverridden());
   EXPECT_TRUE(group1_->sink() == sink1_);
-  EXPECT_TRUE(group1_->hasSinkOverriden());
+  EXPECT_FALSE(group1_->hasSinkOverridden());
 
+  // If parent is set and properties aren't provided, then they are inherited
   EXPECT_TRUE(group2_->parent() == group1_);
   EXPECT_TRUE(group2_->level() == Level::TRACE);
-  EXPECT_FALSE(group2_->hasLevelOverriden());
+  EXPECT_FALSE(group2_->hasLevelOverridden());
   EXPECT_TRUE(group2_->sink() == sink1_);
-  EXPECT_FALSE(group2_->hasSinkOverriden());
+  EXPECT_FALSE(group2_->hasSinkOverridden());
 
+  // If parent is set and properties are provided, then they mark as overridden
   EXPECT_TRUE(group3_->parent() == group2_);
   EXPECT_TRUE(group3_->level() == Level::DEBUG);
-  EXPECT_TRUE(group3_->hasLevelOverriden());
+  EXPECT_TRUE(group3_->hasLevelOverridden());
   EXPECT_TRUE(group3_->sink() == sink3_);
-  EXPECT_TRUE(group3_->hasSinkOverriden());
+  EXPECT_TRUE(group3_->hasSinkOverridden());
 }
 
 TEST_F(GroupTest, ChangeLevel) {
@@ -97,24 +100,24 @@ TEST_F(GroupTest, ChangeLevel) {
   group2_->setLevel(Level::CRITICAL);
   group3_->setLevel(Level::INFO);
 
-  /// @Then level is set and marked as overriden
+  /// @Then level is set and marked as overridden
 
   EXPECT_TRUE(group2_->level() == Level::CRITICAL);
-  EXPECT_TRUE(group2_->hasLevelOverriden());
+  EXPECT_TRUE(group2_->hasLevelOverridden());
   EXPECT_TRUE(group3_->level() == Level::INFO);
-  EXPECT_TRUE(group3_->hasLevelOverriden());
+  EXPECT_TRUE(group3_->hasLevelOverridden());
 
   /// @When reset level
 
   group2_->resetLevel();
   group3_->resetLevel();
 
-  /// @Then level is set from parent group and marked as no overriden
+  /// @Then level is set from parent group and marked as no overridden
 
   EXPECT_TRUE(group2_->level() == Level::TRACE);
-  EXPECT_FALSE(group2_->hasLevelOverriden());
+  EXPECT_FALSE(group2_->hasLevelOverridden());
   EXPECT_TRUE(group3_->level() == Level::TRACE);
-  EXPECT_FALSE(group3_->hasLevelOverriden());
+  EXPECT_FALSE(group3_->hasLevelOverridden());
 }
 
 TEST_F(GroupTest, ChangeSink) {
@@ -123,24 +126,24 @@ TEST_F(GroupTest, ChangeSink) {
   group2_->setSink(sink3_);
   group3_->setSink(sink4_);
 
-  /// @Then sink is set to provided and marked as overriden
+  /// @Then sink is set to provided and marked as overridden
 
   EXPECT_TRUE(group2_->sink() == sink3_);
-  EXPECT_TRUE(group2_->hasSinkOverriden());
+  EXPECT_TRUE(group2_->hasSinkOverridden());
   EXPECT_TRUE(group3_->sink() == sink4_);
-  EXPECT_TRUE(group3_->hasSinkOverriden());
+  EXPECT_TRUE(group3_->hasSinkOverridden());
 
   /// @When reset sink
 
   group2_->resetSink();
   group3_->resetSink();
 
-  /// @Then sink is set from parent group and marked as no overriden
+  /// @Then sink is set from parent group and marked as no overridden
 
   EXPECT_TRUE(group2_->sink() == sink1_);
-  EXPECT_FALSE(group2_->hasSinkOverriden());
+  EXPECT_FALSE(group2_->hasSinkOverridden());
   EXPECT_TRUE(group3_->sink() == sink1_);
-  EXPECT_FALSE(group3_->hasSinkOverriden());
+  EXPECT_FALSE(group3_->hasSinkOverridden());
 }
 
 TEST_F(GroupTest, ChangeGroup) {
@@ -150,36 +153,36 @@ TEST_F(GroupTest, ChangeGroup) {
   group3_->setParentGroup(group4_);
 
   /// @Then parent is changed and
-  ///  no overriden properties are set from new parent group
+  ///  no overridden properties are set from new parent group
 
   EXPECT_TRUE(group2_->parent() == group4_);
   EXPECT_TRUE(group2_->level() == Level::VERBOSE);
-  EXPECT_FALSE(group2_->hasLevelOverriden());
+  EXPECT_FALSE(group2_->hasLevelOverridden());
   EXPECT_TRUE(group2_->sink() == sink4_);
-  EXPECT_FALSE(group2_->hasSinkOverriden());
+  EXPECT_FALSE(group2_->hasSinkOverridden());
 
   EXPECT_TRUE(group3_->parent() == group4_);
   EXPECT_TRUE(group3_->level() == Level::DEBUG);
-  EXPECT_TRUE(group3_->hasLevelOverriden());
+  EXPECT_TRUE(group3_->hasLevelOverridden());
   EXPECT_TRUE(group3_->sink() == sink3_);
-  EXPECT_TRUE(group3_->hasSinkOverriden());
+  EXPECT_TRUE(group3_->hasSinkOverridden());
 
   /// @When unset parent group
 
   group2_->unsetParentGroup();
   group3_->unsetParentGroup();
 
-  /// @Then all properties are marked as overriden
+  /// @Then parent group changes to nullptr
 
   EXPECT_TRUE(group2_->parent() == nullptr);
   EXPECT_TRUE(group2_->level() == Level::VERBOSE);
-  EXPECT_TRUE(group2_->hasLevelOverriden());
+  EXPECT_FALSE(group2_->hasLevelOverridden());
   EXPECT_TRUE(group2_->sink() == sink4_);
-  EXPECT_TRUE(group2_->hasSinkOverriden());
+  EXPECT_FALSE(group2_->hasSinkOverridden());
 
   EXPECT_TRUE(group3_->parent() == nullptr);
   EXPECT_TRUE(group3_->level() == Level::DEBUG);
-  EXPECT_TRUE(group3_->hasLevelOverriden());
+  EXPECT_TRUE(group3_->hasLevelOverridden());
   EXPECT_TRUE(group3_->sink() == sink3_);
-  EXPECT_TRUE(group3_->hasSinkOverriden());
+  EXPECT_TRUE(group3_->hasSinkOverridden());
 }

--- a/test/unit/logger_test.cpp
+++ b/test/unit/logger_test.cpp
@@ -80,27 +80,27 @@ TEST_F(LoggerTest, MakeLogger) {
 
   EXPECT_TRUE(log1_->group() == group1_);
   EXPECT_TRUE(log1_->level() == Level::TRACE);
-  EXPECT_FALSE(log1_->hasLevelOverridden());
+  EXPECT_FALSE(log1_->isLevelOverridden());
   EXPECT_TRUE(log1_->sink() == sink1_);
-  EXPECT_FALSE(log1_->hasSinkOverridden());
+  EXPECT_FALSE(log1_->isSinkOverridden());
 
   EXPECT_TRUE(log2_->group() == group1_);
   EXPECT_TRUE(log2_->level() == Level::TRACE);
-  EXPECT_FALSE(log2_->hasLevelOverridden());
+  EXPECT_FALSE(log2_->isLevelOverridden());
   EXPECT_TRUE(log2_->sink() == sink3_);
-  EXPECT_TRUE(log2_->hasSinkOverridden());
+  EXPECT_TRUE(log2_->isSinkOverridden());
 
   EXPECT_TRUE(log3_->group() == group1_);
   EXPECT_TRUE(log3_->level() == Level::INFO);
-  EXPECT_TRUE(log3_->hasLevelOverridden());
+  EXPECT_TRUE(log3_->isLevelOverridden());
   EXPECT_TRUE(log3_->sink() == sink1_);
-  EXPECT_FALSE(log3_->hasSinkOverridden());
+  EXPECT_FALSE(log3_->isSinkOverridden());
 
   EXPECT_TRUE(log4_->group() == group1_);
   EXPECT_TRUE(log4_->level() == Level::VERBOSE);
-  EXPECT_TRUE(log4_->hasLevelOverridden());
+  EXPECT_TRUE(log4_->isLevelOverridden());
   EXPECT_TRUE(log4_->sink() == sink4_);
-  EXPECT_TRUE(log4_->hasSinkOverridden());
+  EXPECT_TRUE(log4_->isSinkOverridden());
 }
 
 TEST_F(LoggerTest, ChangeLevel) {
@@ -114,13 +114,13 @@ TEST_F(LoggerTest, ChangeLevel) {
   /// @Then level is set and marked as overridden
 
   EXPECT_TRUE(log1_->level() == Level::CRITICAL);
-  EXPECT_TRUE(log1_->hasLevelOverridden());
+  EXPECT_TRUE(log1_->isLevelOverridden());
   EXPECT_TRUE(log2_->level() == Level::CRITICAL);
-  EXPECT_TRUE(log2_->hasLevelOverridden());
+  EXPECT_TRUE(log2_->isLevelOverridden());
   EXPECT_TRUE(log3_->level() == Level::CRITICAL);
-  EXPECT_TRUE(log3_->hasLevelOverridden());
+  EXPECT_TRUE(log3_->isLevelOverridden());
   EXPECT_TRUE(log4_->level() == Level::CRITICAL);
-  EXPECT_TRUE(log4_->hasLevelOverridden());
+  EXPECT_TRUE(log4_->isLevelOverridden());
 
   /// @When reset level
 
@@ -132,13 +132,13 @@ TEST_F(LoggerTest, ChangeLevel) {
   /// @Then level is set from parent group and marked as no overridden
 
   EXPECT_TRUE(log1_->level() == Level::TRACE);
-  EXPECT_FALSE(log1_->hasLevelOverridden());
+  EXPECT_FALSE(log1_->isLevelOverridden());
   EXPECT_TRUE(log2_->level() == Level::TRACE);
-  EXPECT_FALSE(log2_->hasLevelOverridden());
+  EXPECT_FALSE(log2_->isLevelOverridden());
   EXPECT_TRUE(log3_->level() == Level::TRACE);
-  EXPECT_FALSE(log3_->hasLevelOverridden());
+  EXPECT_FALSE(log3_->isLevelOverridden());
   EXPECT_TRUE(log4_->level() == Level::TRACE);
-  EXPECT_FALSE(log4_->hasLevelOverridden());
+  EXPECT_FALSE(log4_->isLevelOverridden());
 }
 
 TEST_F(LoggerTest, ChangeSink) {
@@ -152,13 +152,13 @@ TEST_F(LoggerTest, ChangeSink) {
   /// @Then sink is set to provided and marked as overridden
 
   EXPECT_TRUE(log1_->sink() == sink2_);
-  EXPECT_TRUE(log1_->hasSinkOverridden());
+  EXPECT_TRUE(log1_->isSinkOverridden());
   EXPECT_TRUE(log2_->sink() == sink2_);
-  EXPECT_TRUE(log2_->hasSinkOverridden());
+  EXPECT_TRUE(log2_->isSinkOverridden());
   EXPECT_TRUE(log3_->sink() == sink2_);
-  EXPECT_TRUE(log3_->hasSinkOverridden());
+  EXPECT_TRUE(log3_->isSinkOverridden());
   EXPECT_TRUE(log4_->sink() == sink2_);
-  EXPECT_TRUE(log4_->hasSinkOverridden());
+  EXPECT_TRUE(log4_->isSinkOverridden());
 
   /// @When reset sink
 
@@ -170,13 +170,13 @@ TEST_F(LoggerTest, ChangeSink) {
   /// @Then sink is set from parent group and marked as no overridden
 
   EXPECT_TRUE(log1_->sink() == sink1_);
-  EXPECT_FALSE(log1_->hasSinkOverridden());
+  EXPECT_FALSE(log1_->isSinkOverridden());
   EXPECT_TRUE(log2_->sink() == sink1_);
-  EXPECT_FALSE(log2_->hasSinkOverridden());
+  EXPECT_FALSE(log2_->isSinkOverridden());
   EXPECT_TRUE(log3_->sink() == sink1_);
-  EXPECT_FALSE(log3_->hasSinkOverridden());
+  EXPECT_FALSE(log3_->isSinkOverridden());
   EXPECT_TRUE(log4_->sink() == sink1_);
-  EXPECT_FALSE(log4_->hasSinkOverridden());
+  EXPECT_FALSE(log4_->isSinkOverridden());
 }
 
 TEST_F(LoggerTest, ChangeGroup) {
@@ -192,25 +192,25 @@ TEST_F(LoggerTest, ChangeGroup) {
 
   EXPECT_TRUE(log1_->group() == group2_);
   EXPECT_TRUE(log1_->level() == Level::DEBUG);
-  EXPECT_FALSE(log1_->hasLevelOverridden());
+  EXPECT_FALSE(log1_->isLevelOverridden());
   EXPECT_TRUE(log1_->sink() == sink2_);
-  EXPECT_FALSE(log1_->hasSinkOverridden());
+  EXPECT_FALSE(log1_->isSinkOverridden());
 
   EXPECT_TRUE(log2_->group() == group2_);
   EXPECT_TRUE(log2_->level() == Level::DEBUG);
-  EXPECT_FALSE(log2_->hasLevelOverridden());
+  EXPECT_FALSE(log2_->isLevelOverridden());
   EXPECT_TRUE(log2_->sink() == sink3_);
-  EXPECT_TRUE(log2_->hasSinkOverridden());
+  EXPECT_TRUE(log2_->isSinkOverridden());
 
   EXPECT_TRUE(log3_->group() == group2_);
   EXPECT_TRUE(log3_->level() == Level::INFO);
-  EXPECT_TRUE(log3_->hasLevelOverridden());
+  EXPECT_TRUE(log3_->isLevelOverridden());
   EXPECT_TRUE(log3_->sink() == sink2_);
-  EXPECT_FALSE(log3_->hasSinkOverridden());
+  EXPECT_FALSE(log3_->isSinkOverridden());
 
   EXPECT_TRUE(log4_->group() == group2_);
   EXPECT_TRUE(log4_->level() == Level::VERBOSE);
-  EXPECT_TRUE(log4_->hasLevelOverridden());
+  EXPECT_TRUE(log4_->isLevelOverridden());
   EXPECT_TRUE(log4_->sink() == sink4_);
-  EXPECT_TRUE(log4_->hasSinkOverridden());
+  EXPECT_TRUE(log4_->isSinkOverridden());
 }

--- a/test/unit/logger_test.cpp
+++ b/test/unit/logger_test.cpp
@@ -80,27 +80,27 @@ TEST_F(LoggerTest, MakeLogger) {
 
   EXPECT_TRUE(log1_->group() == group1_);
   EXPECT_TRUE(log1_->level() == Level::TRACE);
-  EXPECT_FALSE(log1_->hasLevelOverriden());
+  EXPECT_FALSE(log1_->hasLevelOverridden());
   EXPECT_TRUE(log1_->sink() == sink1_);
-  EXPECT_FALSE(log1_->hasSinkOverriden());
+  EXPECT_FALSE(log1_->hasSinkOverridden());
 
   EXPECT_TRUE(log2_->group() == group1_);
   EXPECT_TRUE(log2_->level() == Level::TRACE);
-  EXPECT_FALSE(log2_->hasLevelOverriden());
+  EXPECT_FALSE(log2_->hasLevelOverridden());
   EXPECT_TRUE(log2_->sink() == sink3_);
-  EXPECT_TRUE(log2_->hasSinkOverriden());
+  EXPECT_TRUE(log2_->hasSinkOverridden());
 
   EXPECT_TRUE(log3_->group() == group1_);
   EXPECT_TRUE(log3_->level() == Level::INFO);
-  EXPECT_TRUE(log3_->hasLevelOverriden());
+  EXPECT_TRUE(log3_->hasLevelOverridden());
   EXPECT_TRUE(log3_->sink() == sink1_);
-  EXPECT_FALSE(log3_->hasSinkOverriden());
+  EXPECT_FALSE(log3_->hasSinkOverridden());
 
   EXPECT_TRUE(log4_->group() == group1_);
   EXPECT_TRUE(log4_->level() == Level::VERBOSE);
-  EXPECT_TRUE(log4_->hasLevelOverriden());
+  EXPECT_TRUE(log4_->hasLevelOverridden());
   EXPECT_TRUE(log4_->sink() == sink4_);
-  EXPECT_TRUE(log4_->hasSinkOverriden());
+  EXPECT_TRUE(log4_->hasSinkOverridden());
 }
 
 TEST_F(LoggerTest, ChangeLevel) {
@@ -111,16 +111,16 @@ TEST_F(LoggerTest, ChangeLevel) {
   log3_->setLevel(Level::CRITICAL);
   log4_->setLevel(Level::CRITICAL);
 
-  /// @Then level is set and marked as overriden
+  /// @Then level is set and marked as overridden
 
   EXPECT_TRUE(log1_->level() == Level::CRITICAL);
-  EXPECT_TRUE(log1_->hasLevelOverriden());
+  EXPECT_TRUE(log1_->hasLevelOverridden());
   EXPECT_TRUE(log2_->level() == Level::CRITICAL);
-  EXPECT_TRUE(log2_->hasLevelOverriden());
+  EXPECT_TRUE(log2_->hasLevelOverridden());
   EXPECT_TRUE(log3_->level() == Level::CRITICAL);
-  EXPECT_TRUE(log3_->hasLevelOverriden());
+  EXPECT_TRUE(log3_->hasLevelOverridden());
   EXPECT_TRUE(log4_->level() == Level::CRITICAL);
-  EXPECT_TRUE(log4_->hasLevelOverriden());
+  EXPECT_TRUE(log4_->hasLevelOverridden());
 
   /// @When reset level
 
@@ -129,16 +129,16 @@ TEST_F(LoggerTest, ChangeLevel) {
   log3_->resetLevel();
   log4_->resetLevel();
 
-  /// @Then level is set from parent group and marked as no overriden
+  /// @Then level is set from parent group and marked as no overridden
 
   EXPECT_TRUE(log1_->level() == Level::TRACE);
-  EXPECT_FALSE(log1_->hasLevelOverriden());
+  EXPECT_FALSE(log1_->hasLevelOverridden());
   EXPECT_TRUE(log2_->level() == Level::TRACE);
-  EXPECT_FALSE(log2_->hasLevelOverriden());
+  EXPECT_FALSE(log2_->hasLevelOverridden());
   EXPECT_TRUE(log3_->level() == Level::TRACE);
-  EXPECT_FALSE(log3_->hasLevelOverriden());
+  EXPECT_FALSE(log3_->hasLevelOverridden());
   EXPECT_TRUE(log4_->level() == Level::TRACE);
-  EXPECT_FALSE(log4_->hasLevelOverriden());
+  EXPECT_FALSE(log4_->hasLevelOverridden());
 }
 
 TEST_F(LoggerTest, ChangeSink) {
@@ -149,16 +149,16 @@ TEST_F(LoggerTest, ChangeSink) {
   log3_->setSink(sink2_);
   log4_->setSink(sink2_);
 
-  /// @Then sink is set to provided and marked as overriden
+  /// @Then sink is set to provided and marked as overridden
 
   EXPECT_TRUE(log1_->sink() == sink2_);
-  EXPECT_TRUE(log1_->hasSinkOverriden());
+  EXPECT_TRUE(log1_->hasSinkOverridden());
   EXPECT_TRUE(log2_->sink() == sink2_);
-  EXPECT_TRUE(log2_->hasSinkOverriden());
+  EXPECT_TRUE(log2_->hasSinkOverridden());
   EXPECT_TRUE(log3_->sink() == sink2_);
-  EXPECT_TRUE(log3_->hasSinkOverriden());
+  EXPECT_TRUE(log3_->hasSinkOverridden());
   EXPECT_TRUE(log4_->sink() == sink2_);
-  EXPECT_TRUE(log4_->hasSinkOverriden());
+  EXPECT_TRUE(log4_->hasSinkOverridden());
 
   /// @When reset sink
 
@@ -167,16 +167,16 @@ TEST_F(LoggerTest, ChangeSink) {
   log3_->resetSink();
   log4_->resetSink();
 
-  /// @Then sink is set from parent group and marked as no overriden
+  /// @Then sink is set from parent group and marked as no overridden
 
   EXPECT_TRUE(log1_->sink() == sink1_);
-  EXPECT_FALSE(log1_->hasSinkOverriden());
+  EXPECT_FALSE(log1_->hasSinkOverridden());
   EXPECT_TRUE(log2_->sink() == sink1_);
-  EXPECT_FALSE(log2_->hasSinkOverriden());
+  EXPECT_FALSE(log2_->hasSinkOverridden());
   EXPECT_TRUE(log3_->sink() == sink1_);
-  EXPECT_FALSE(log3_->hasSinkOverriden());
+  EXPECT_FALSE(log3_->hasSinkOverridden());
   EXPECT_TRUE(log4_->sink() == sink1_);
-  EXPECT_FALSE(log4_->hasSinkOverriden());
+  EXPECT_FALSE(log4_->hasSinkOverridden());
 }
 
 TEST_F(LoggerTest, ChangeGroup) {
@@ -188,29 +188,29 @@ TEST_F(LoggerTest, ChangeGroup) {
   log4_->setGroup(group2_);
 
   /// @Then parent is changed and
-  ///  no overriden properties are set from new parent group
+  ///  no overridden properties are set from new parent group
 
   EXPECT_TRUE(log1_->group() == group2_);
   EXPECT_TRUE(log1_->level() == Level::DEBUG);
-  EXPECT_FALSE(log1_->hasLevelOverriden());
+  EXPECT_FALSE(log1_->hasLevelOverridden());
   EXPECT_TRUE(log1_->sink() == sink2_);
-  EXPECT_FALSE(log1_->hasSinkOverriden());
+  EXPECT_FALSE(log1_->hasSinkOverridden());
 
   EXPECT_TRUE(log2_->group() == group2_);
   EXPECT_TRUE(log2_->level() == Level::DEBUG);
-  EXPECT_FALSE(log2_->hasLevelOverriden());
+  EXPECT_FALSE(log2_->hasLevelOverridden());
   EXPECT_TRUE(log2_->sink() == sink3_);
-  EXPECT_TRUE(log2_->hasSinkOverriden());
+  EXPECT_TRUE(log2_->hasSinkOverridden());
 
   EXPECT_TRUE(log3_->group() == group2_);
   EXPECT_TRUE(log3_->level() == Level::INFO);
-  EXPECT_TRUE(log3_->hasLevelOverriden());
+  EXPECT_TRUE(log3_->hasLevelOverridden());
   EXPECT_TRUE(log3_->sink() == sink2_);
-  EXPECT_FALSE(log3_->hasSinkOverriden());
+  EXPECT_FALSE(log3_->hasSinkOverridden());
 
   EXPECT_TRUE(log4_->group() == group2_);
   EXPECT_TRUE(log4_->level() == Level::VERBOSE);
-  EXPECT_TRUE(log4_->hasLevelOverriden());
+  EXPECT_TRUE(log4_->hasLevelOverridden());
   EXPECT_TRUE(log4_->sink() == sink4_);
-  EXPECT_TRUE(log4_->hasSinkOverriden());
+  EXPECT_TRUE(log4_->hasSinkOverridden());
 }

--- a/test/unit/logging_system_test.cpp
+++ b/test/unit/logging_system_test.cpp
@@ -235,37 +235,37 @@ TEST_F(LoggingSystemTest, ChangeLevelOfGroup) {
 
   auto expect_initial_state = [&] {
     EXPECT_TRUE(group1->level() == Level::INFO);
-    EXPECT_FALSE(group1->hasLevelOverridden());
+    EXPECT_FALSE(group1->isLevelOverridden());
 
     EXPECT_TRUE(group2->level() == group1->level());
-    EXPECT_FALSE(group2->hasLevelOverridden());
+    EXPECT_FALSE(group2->isLevelOverridden());
 
     EXPECT_TRUE(group3->level() == Level::WARN);
-    EXPECT_TRUE(group3->hasLevelOverridden());
+    EXPECT_TRUE(group3->isLevelOverridden());
 
     EXPECT_TRUE(log1->level() == Level::INFO);
     EXPECT_TRUE(log1->level() == group2->level());
-    EXPECT_FALSE(log1->hasLevelOverridden());
+    EXPECT_FALSE(log1->isLevelOverridden());
 
     EXPECT_TRUE(log2->level() == Level::TRACE);
     EXPECT_TRUE(log2->level() != group1->level());
-    EXPECT_TRUE(log2->hasLevelOverridden());
+    EXPECT_TRUE(log2->isLevelOverridden());
 
     EXPECT_TRUE(log3->level() == Level::INFO);
     EXPECT_TRUE(log3->level() == group2->level());
-    EXPECT_FALSE(log3->hasLevelOverridden());
+    EXPECT_FALSE(log3->isLevelOverridden());
 
     EXPECT_TRUE(log4->level() == Level::DEBUG);
     EXPECT_TRUE(log4->level() != group2->level());
-    EXPECT_TRUE(log4->hasLevelOverridden());
+    EXPECT_TRUE(log4->isLevelOverridden());
 
     EXPECT_TRUE(log5->level() == Level::WARN);
     EXPECT_TRUE(log5->level() == group3->level());
-    EXPECT_FALSE(log5->hasLevelOverridden());
+    EXPECT_FALSE(log5->isLevelOverridden());
 
     EXPECT_TRUE(log6->level() == Level::VERBOSE);
     EXPECT_TRUE(log6->level() != group3->level());
-    EXPECT_TRUE(log6->hasLevelOverridden());
+    EXPECT_TRUE(log6->isLevelOverridden());
   };
 
   /// @Given beginning state of groups
@@ -297,25 +297,25 @@ TEST_F(LoggingSystemTest, ChangeLevelOfGroup) {
 
   // Properties not overridden because group doesn't have parent
   EXPECT_TRUE(group1->level() == Level::CRITICAL);  // *own
-  EXPECT_FALSE(group1->hasLevelOverridden());
+  EXPECT_FALSE(group1->isLevelOverridden());
   EXPECT_TRUE(group2->level() == Level::CRITICAL);  // *g1
   EXPECT_FALSE(
-      group2->hasLevelOverridden());  // no overridden because no parent
+      group2->isLevelOverridden());  // no overridden because no parent
   EXPECT_TRUE(group3->level() == Level::WARN);  // own
-  EXPECT_TRUE(group3->hasLevelOverridden());
+  EXPECT_TRUE(group3->isLevelOverridden());
 
   EXPECT_TRUE(log1->level() == Level::CRITICAL);  // *g1
-  EXPECT_FALSE(log1->hasLevelOverridden());
+  EXPECT_FALSE(log1->isLevelOverridden());
   EXPECT_TRUE(log2->level() == Level::TRACE);  // own
-  EXPECT_TRUE(log2->hasLevelOverridden());
+  EXPECT_TRUE(log2->isLevelOverridden());
   EXPECT_TRUE(log3->level() == Level::CRITICAL);  // *g2<-g1
-  EXPECT_FALSE(log3->hasLevelOverridden());
+  EXPECT_FALSE(log3->isLevelOverridden());
   EXPECT_TRUE(log4->level() == Level::DEBUG);  // own
-  EXPECT_TRUE(log4->hasLevelOverridden());
+  EXPECT_TRUE(log4->isLevelOverridden());
   EXPECT_TRUE(log5->level() == Level::WARN);  // g3
-  EXPECT_FALSE(log5->hasLevelOverridden());
+  EXPECT_FALSE(log5->isLevelOverridden());
   EXPECT_TRUE(log6->level() == Level::VERBOSE);  // own
-  EXPECT_TRUE(log6->hasLevelOverridden());
+  EXPECT_TRUE(log6->isLevelOverridden());
 
   /// @When coming back previous group's level
   system_->setLevelOfGroup("first", Level::INFO);
@@ -339,24 +339,24 @@ TEST_F(LoggingSystemTest, ChangeLevelOfGroup) {
   //                       ^
 
   EXPECT_TRUE(group1->level() == Level::INFO);  // own
-  EXPECT_FALSE(group1->hasLevelOverridden());
+  EXPECT_FALSE(group1->isLevelOverridden());
   EXPECT_TRUE(group2->level() == Level::CRITICAL);  // *own
-  EXPECT_TRUE(group2->hasLevelOverridden());
+  EXPECT_TRUE(group2->isLevelOverridden());
   EXPECT_TRUE(group3->level() == Level::WARN);  // own
-  EXPECT_TRUE(group3->hasLevelOverridden());
+  EXPECT_TRUE(group3->isLevelOverridden());
 
   EXPECT_TRUE(log1->level() == Level::INFO);  // g1
-  EXPECT_FALSE(log1->hasLevelOverridden());
+  EXPECT_FALSE(log1->isLevelOverridden());
   EXPECT_TRUE(log2->level() == Level::TRACE);  // own
-  EXPECT_TRUE(log2->hasLevelOverridden());
+  EXPECT_TRUE(log2->isLevelOverridden());
   EXPECT_TRUE(log3->level() == Level::CRITICAL);  // *g2
-  EXPECT_FALSE(log3->hasLevelOverridden());
+  EXPECT_FALSE(log3->isLevelOverridden());
   EXPECT_TRUE(log4->level() == Level::DEBUG);  // own
-  EXPECT_TRUE(log4->hasLevelOverridden());
+  EXPECT_TRUE(log4->isLevelOverridden());
   EXPECT_TRUE(log5->level() == Level::WARN);  // g3
-  EXPECT_FALSE(log5->hasLevelOverridden());
+  EXPECT_FALSE(log5->isLevelOverridden());
   EXPECT_TRUE(log6->level() == Level::VERBOSE);  // own
-  EXPECT_TRUE(log6->hasLevelOverridden());
+  EXPECT_TRUE(log6->isLevelOverridden());
 
   /// @When come back dependent of top group
   system_->resetLevelOfGroup("second");
@@ -420,37 +420,37 @@ TEST_F(LoggingSystemTest, ChangeSinkOfGroup) {
 
   auto expect_initial_state = [&] {
     EXPECT_TRUE(group1->sink() == sink1);
-    EXPECT_FALSE(group1->hasSinkOverridden());
+    EXPECT_FALSE(group1->isSinkOverridden());
 
     EXPECT_TRUE(group2->sink() == group1->sink());
-    EXPECT_FALSE(group2->hasSinkOverridden());
+    EXPECT_FALSE(group2->isSinkOverridden());
 
     EXPECT_TRUE(group3->sink() == sink2);
-    EXPECT_TRUE(group3->hasSinkOverridden());
+    EXPECT_TRUE(group3->isSinkOverridden());
 
     EXPECT_TRUE(log1->sink() == sink1);
     EXPECT_TRUE(log1->sink() == group2->sink());
-    EXPECT_FALSE(log1->hasSinkOverridden());
+    EXPECT_FALSE(log1->isSinkOverridden());
 
     EXPECT_TRUE(log2->sink() == sink3);
     EXPECT_TRUE(log2->sink() != group1->sink());
-    EXPECT_TRUE(log2->hasSinkOverridden());
+    EXPECT_TRUE(log2->isSinkOverridden());
 
     EXPECT_TRUE(log3->sink() == sink1);
     EXPECT_TRUE(log3->sink() == group2->sink());
-    EXPECT_FALSE(log3->hasSinkOverridden());
+    EXPECT_FALSE(log3->isSinkOverridden());
 
     EXPECT_TRUE(log4->sink() == sink4);
     EXPECT_TRUE(log4->sink() != group2->sink());
-    EXPECT_TRUE(log4->hasSinkOverridden());
+    EXPECT_TRUE(log4->isSinkOverridden());
 
     EXPECT_TRUE(log5->sink() == sink2);
     EXPECT_TRUE(log5->sink() == group3->sink());
-    EXPECT_FALSE(log5->hasSinkOverridden());
+    EXPECT_FALSE(log5->isSinkOverridden());
 
     EXPECT_TRUE(log6->sink() == sink5);
     EXPECT_TRUE(log6->sink() != group3->sink());
-    EXPECT_TRUE(log6->hasSinkOverridden());
+    EXPECT_TRUE(log6->isSinkOverridden());
   };
 
   /// @Given beginning state of groups
@@ -481,24 +481,24 @@ TEST_F(LoggingSystemTest, ChangeSinkOfGroup) {
   //              ^           ^
 
   EXPECT_TRUE(group1->sink() == sink6);  // *own
-  EXPECT_FALSE(group1->hasSinkOverridden());
+  EXPECT_FALSE(group1->isSinkOverridden());
   EXPECT_TRUE(group2->sink() == sink6);  // *g1
-  EXPECT_FALSE(group2->hasSinkOverridden());
+  EXPECT_FALSE(group2->isSinkOverridden());
   EXPECT_TRUE(group3->sink() == sink2);  // own
-  EXPECT_TRUE(group3->hasSinkOverridden());
+  EXPECT_TRUE(group3->isSinkOverridden());
 
   EXPECT_TRUE(log1->sink() == sink6);  // *g1
-  EXPECT_FALSE(log1->hasSinkOverridden());
+  EXPECT_FALSE(log1->isSinkOverridden());
   EXPECT_TRUE(log2->sink() == sink3);  // own
-  EXPECT_TRUE(log2->hasSinkOverridden());
+  EXPECT_TRUE(log2->isSinkOverridden());
   EXPECT_TRUE(log3->sink() == sink6);  // *g2<-g1
-  EXPECT_FALSE(log3->hasSinkOverridden());
+  EXPECT_FALSE(log3->isSinkOverridden());
   EXPECT_TRUE(log4->sink() == sink4);  // own
-  EXPECT_TRUE(log4->hasSinkOverridden());
+  EXPECT_TRUE(log4->isSinkOverridden());
   EXPECT_TRUE(log5->sink() == sink2);  // g3
-  EXPECT_FALSE(log5->hasSinkOverridden());
+  EXPECT_FALSE(log5->isSinkOverridden());
   EXPECT_TRUE(log6->sink() == sink5);  // own
-  EXPECT_TRUE(log6->hasSinkOverridden());
+  EXPECT_TRUE(log6->isSinkOverridden());
 
   /// @When come back sink of top group
   system_->setSinkOfGroup("first", "sink1");
@@ -522,24 +522,24 @@ TEST_F(LoggingSystemTest, ChangeSinkOfGroup) {
   //                       ^
 
   EXPECT_TRUE(group1->sink() == sink1);  // own
-  EXPECT_FALSE(group1->hasSinkOverridden());
+  EXPECT_FALSE(group1->isSinkOverridden());
   EXPECT_TRUE(group2->sink() == sink6);  // *own
-  EXPECT_TRUE(group2->hasSinkOverridden());
+  EXPECT_TRUE(group2->isSinkOverridden());
   EXPECT_TRUE(group3->sink() == sink2);  // own
-  EXPECT_TRUE(group3->hasSinkOverridden());
+  EXPECT_TRUE(group3->isSinkOverridden());
 
   EXPECT_TRUE(log1->sink() == sink1);  // g1
-  EXPECT_FALSE(log1->hasSinkOverridden());
+  EXPECT_FALSE(log1->isSinkOverridden());
   EXPECT_TRUE(log2->sink() == sink3);  // own
-  EXPECT_TRUE(log2->hasSinkOverridden());
+  EXPECT_TRUE(log2->isSinkOverridden());
   EXPECT_TRUE(log3->sink() == sink6);  // *g2
-  EXPECT_FALSE(log3->hasSinkOverridden());
+  EXPECT_FALSE(log3->isSinkOverridden());
   EXPECT_TRUE(log4->sink() == sink4);  // own
-  EXPECT_TRUE(log4->hasSinkOverridden());
+  EXPECT_TRUE(log4->isSinkOverridden());
   EXPECT_TRUE(log5->sink() == sink2);  // g3
-  EXPECT_FALSE(log5->hasSinkOverridden());
+  EXPECT_FALSE(log5->isSinkOverridden());
   EXPECT_TRUE(log6->sink() == sink5);  // own
-  EXPECT_TRUE(log6->hasSinkOverridden());
+  EXPECT_TRUE(log6->isSinkOverridden());
 
   /// @When come back dependent of top group
   system_->resetSinkOfGroup("second");
@@ -618,49 +618,49 @@ TEST_F(LoggingSystemTest, ChangeParentGroup) {
 
   EXPECT_TRUE(group11->parent() == nullptr);
   EXPECT_TRUE(group11->sink() == sink1);
-  EXPECT_FALSE(group11->hasSinkOverridden());
+  EXPECT_FALSE(group11->isSinkOverridden());
   EXPECT_TRUE(group11->level() == Level::TRACE);
-  EXPECT_FALSE(group11->hasLevelOverridden());
+  EXPECT_FALSE(group11->isLevelOverridden());
   EXPECT_TRUE(log1->sink() == sink1);
   EXPECT_TRUE(log1->level() == Level::TRACE);
 
   EXPECT_TRUE(group12->parent() == nullptr);
   EXPECT_TRUE(group12->sink() == sink2);
-  EXPECT_FALSE(group12->hasSinkOverridden());
+  EXPECT_FALSE(group12->isSinkOverridden());
   EXPECT_TRUE(group12->level() == Level::DEBUG);
-  EXPECT_FALSE(group12->hasLevelOverridden());
+  EXPECT_FALSE(group12->isLevelOverridden());
   EXPECT_TRUE(log2->sink() == sink2);
   EXPECT_TRUE(log2->level() == Level::DEBUG);
 
   EXPECT_TRUE(group21->parent() == group11);
   EXPECT_TRUE(group21->sink() == sink1);
-  EXPECT_FALSE(group21->hasSinkOverridden());
+  EXPECT_FALSE(group21->isSinkOverridden());
   EXPECT_TRUE(group21->level() == Level::TRACE);
-  EXPECT_FALSE(group21->hasLevelOverridden());
+  EXPECT_FALSE(group21->isLevelOverridden());
   EXPECT_TRUE(log3->sink() == sink1);
   EXPECT_TRUE(log3->level() == Level::TRACE);
 
   EXPECT_TRUE(group22->parent() == group11);
   EXPECT_TRUE(group22->sink() == sink1);
-  EXPECT_FALSE(group22->hasSinkOverridden());
+  EXPECT_FALSE(group22->isSinkOverridden());
   EXPECT_TRUE(group22->level() == Level::TRACE);
-  EXPECT_FALSE(group22->hasLevelOverridden());
+  EXPECT_FALSE(group22->isLevelOverridden());
   EXPECT_TRUE(log4->sink() == sink1);
   EXPECT_TRUE(log4->level() == Level::TRACE);
 
   EXPECT_TRUE(group31->parent() == group21);
   EXPECT_TRUE(group31->sink() == sink3);
-  EXPECT_TRUE(group31->hasSinkOverridden());
+  EXPECT_TRUE(group31->isSinkOverridden());
   EXPECT_TRUE(group31->level() == Level::TRACE);
-  EXPECT_FALSE(group31->hasLevelOverridden());
+  EXPECT_FALSE(group31->isLevelOverridden());
   EXPECT_TRUE(log5->sink() == sink3);
   EXPECT_TRUE(log5->level() == Level::TRACE);
 
   EXPECT_TRUE(group32->parent() == group21);
   EXPECT_TRUE(group32->sink() == sink1);
-  EXPECT_FALSE(group32->hasSinkOverridden());
+  EXPECT_FALSE(group32->isSinkOverridden());
   EXPECT_TRUE(group32->level() == Level::CRITICAL);
-  EXPECT_TRUE(group32->hasLevelOverridden());
+  EXPECT_TRUE(group32->isLevelOverridden());
   EXPECT_TRUE(log6->sink() == sink1);
   EXPECT_TRUE(log6->level() == Level::CRITICAL);
 
@@ -680,49 +680,49 @@ TEST_F(LoggingSystemTest, ChangeParentGroup) {
 
   EXPECT_TRUE(group11->parent() == nullptr);
   EXPECT_TRUE(group11->sink() == sink1);
-  EXPECT_FALSE(group11->hasSinkOverridden());
+  EXPECT_FALSE(group11->isSinkOverridden());
   EXPECT_TRUE(group11->level() == Level::TRACE);
-  EXPECT_FALSE(group11->hasLevelOverridden());
+  EXPECT_FALSE(group11->isLevelOverridden());
   EXPECT_TRUE(log1->sink() == sink1);
   EXPECT_TRUE(log1->level() == Level::TRACE);
 
   EXPECT_TRUE(group12->parent() == nullptr);
   EXPECT_TRUE(group12->sink() == sink2);
-  EXPECT_FALSE(group12->hasSinkOverridden());
+  EXPECT_FALSE(group12->isSinkOverridden());
   EXPECT_TRUE(group12->level() == Level::DEBUG);
-  EXPECT_FALSE(group12->hasLevelOverridden());
+  EXPECT_FALSE(group12->isLevelOverridden());
   EXPECT_TRUE(log2->sink() == sink2);
   EXPECT_TRUE(log2->level() == Level::DEBUG);
 
   EXPECT_TRUE(group21->parent() == group12);
   EXPECT_TRUE(group21->sink() == sink2);
-  EXPECT_FALSE(group21->hasSinkOverridden());
+  EXPECT_FALSE(group21->isSinkOverridden());
   EXPECT_TRUE(group21->level() == Level::DEBUG);
-  EXPECT_FALSE(group21->hasLevelOverridden());
+  EXPECT_FALSE(group21->isLevelOverridden());
   EXPECT_TRUE(log3->sink() == sink2);
   EXPECT_TRUE(log3->level() == Level::DEBUG);
 
   EXPECT_TRUE(group22->parent() == group11);
   EXPECT_TRUE(group22->sink() == sink1);
-  EXPECT_FALSE(group22->hasSinkOverridden());
+  EXPECT_FALSE(group22->isSinkOverridden());
   EXPECT_TRUE(group22->level() == Level::TRACE);
-  EXPECT_FALSE(group22->hasLevelOverridden());
+  EXPECT_FALSE(group22->isLevelOverridden());
   EXPECT_TRUE(log4->sink() == sink1);
   EXPECT_TRUE(log4->level() == Level::TRACE);
 
   EXPECT_TRUE(group31->parent() == group21);
   EXPECT_TRUE(group31->sink() == sink3);
-  EXPECT_TRUE(group31->hasSinkOverridden());
+  EXPECT_TRUE(group31->isSinkOverridden());
   EXPECT_TRUE(group31->level() == Level::DEBUG);
-  EXPECT_FALSE(group31->hasLevelOverridden());
+  EXPECT_FALSE(group31->isLevelOverridden());
   EXPECT_TRUE(log5->sink() == sink3);
   EXPECT_TRUE(log5->level() == Level::DEBUG);
 
   EXPECT_TRUE(group32->parent() == group21);
   EXPECT_TRUE(group32->sink() == sink2);
-  EXPECT_FALSE(group32->hasSinkOverridden());
+  EXPECT_FALSE(group32->isSinkOverridden());
   EXPECT_TRUE(group32->level() == Level::CRITICAL);
-  EXPECT_TRUE(group32->hasLevelOverridden());
+  EXPECT_TRUE(group32->isLevelOverridden());
   EXPECT_TRUE(log6->sink() == sink2);
   EXPECT_TRUE(log6->level() == Level::CRITICAL);
 
@@ -742,49 +742,49 @@ TEST_F(LoggingSystemTest, ChangeParentGroup) {
 
   EXPECT_TRUE(group11->parent() == nullptr);
   EXPECT_TRUE(group11->sink() == sink1);
-  EXPECT_FALSE(group11->hasSinkOverridden());
+  EXPECT_FALSE(group11->isSinkOverridden());
   EXPECT_TRUE(group11->level() == Level::TRACE);
-  EXPECT_FALSE(group11->hasLevelOverridden());
+  EXPECT_FALSE(group11->isLevelOverridden());
   EXPECT_TRUE(log1->sink() == sink1);
   EXPECT_TRUE(log1->level() == Level::TRACE);
 
   EXPECT_TRUE(group12->parent() == nullptr);
   EXPECT_TRUE(group12->sink() == sink2);
-  EXPECT_FALSE(group12->hasSinkOverridden());
+  EXPECT_FALSE(group12->isSinkOverridden());
   EXPECT_TRUE(group12->level() == Level::DEBUG);
-  EXPECT_FALSE(group12->hasLevelOverridden());
+  EXPECT_FALSE(group12->isLevelOverridden());
   EXPECT_TRUE(log2->sink() == sink2);
   EXPECT_TRUE(log2->level() == Level::DEBUG);
 
   EXPECT_TRUE(group21->parent() == group12);
   EXPECT_TRUE(group21->sink() == sink2);
-  EXPECT_FALSE(group21->hasSinkOverridden());
+  EXPECT_FALSE(group21->isSinkOverridden());
   EXPECT_TRUE(group21->level() == Level::DEBUG);
-  EXPECT_FALSE(group21->hasLevelOverridden());
+  EXPECT_FALSE(group21->isLevelOverridden());
   EXPECT_TRUE(log3->sink() == sink2);
   EXPECT_TRUE(log3->level() == Level::DEBUG);
 
   EXPECT_TRUE(group22->parent() == group11);
   EXPECT_TRUE(group22->sink() == sink1);
-  EXPECT_FALSE(group22->hasSinkOverridden());
+  EXPECT_FALSE(group22->isSinkOverridden());
   EXPECT_TRUE(group22->level() == Level::TRACE);
-  EXPECT_FALSE(group22->hasLevelOverridden());
+  EXPECT_FALSE(group22->isLevelOverridden());
   EXPECT_TRUE(log4->sink() == sink1);
   EXPECT_TRUE(log4->level() == Level::TRACE);
 
   EXPECT_TRUE(group31->parent() == nullptr);
   EXPECT_TRUE(group31->sink() == sink3);
-  EXPECT_TRUE(group31->hasSinkOverridden());
+  EXPECT_TRUE(group31->isSinkOverridden());
   EXPECT_TRUE(group31->level() == Level::DEBUG);
-  EXPECT_FALSE(group31->hasLevelOverridden());
+  EXPECT_FALSE(group31->isLevelOverridden());
   EXPECT_TRUE(log5->sink() == sink3);
   EXPECT_TRUE(log5->level() == Level::DEBUG);
 
   EXPECT_TRUE(group32->parent() == group21);
   EXPECT_TRUE(group32->sink() == sink2);
-  EXPECT_FALSE(group32->hasSinkOverridden());
+  EXPECT_FALSE(group32->isSinkOverridden());
   EXPECT_TRUE(group32->level() == Level::CRITICAL);
-  EXPECT_TRUE(group32->hasLevelOverridden());
+  EXPECT_TRUE(group32->isLevelOverridden());
   EXPECT_TRUE(log6->sink() == sink2);
   EXPECT_TRUE(log6->level() == Level::CRITICAL);
 
@@ -804,49 +804,49 @@ TEST_F(LoggingSystemTest, ChangeParentGroup) {
 
   EXPECT_TRUE(group11->parent() == nullptr);
   EXPECT_TRUE(group11->sink() == sink1);
-  EXPECT_FALSE(group11->hasSinkOverridden());
+  EXPECT_FALSE(group11->isSinkOverridden());
   EXPECT_TRUE(group11->level() == Level::TRACE);
-  EXPECT_FALSE(group11->hasLevelOverridden());
+  EXPECT_FALSE(group11->isLevelOverridden());
   EXPECT_TRUE(log1->sink() == sink1);
   EXPECT_TRUE(log1->level() == Level::TRACE);
 
   EXPECT_TRUE(group12->parent() == nullptr);
   EXPECT_TRUE(group12->sink() == sink2);
-  EXPECT_FALSE(group12->hasSinkOverridden());
+  EXPECT_FALSE(group12->isSinkOverridden());
   EXPECT_TRUE(group12->level() == Level::DEBUG);
-  EXPECT_FALSE(group12->hasLevelOverridden());
+  EXPECT_FALSE(group12->isLevelOverridden());
   EXPECT_TRUE(log2->sink() == sink2);
   EXPECT_TRUE(log2->level() == Level::DEBUG);
 
   EXPECT_TRUE(group21->parent() == group12);
   EXPECT_TRUE(group21->sink() == sink2);
-  EXPECT_FALSE(group21->hasSinkOverridden());
+  EXPECT_FALSE(group21->isSinkOverridden());
   EXPECT_TRUE(group21->level() == Level::INFO);
-  EXPECT_TRUE(group21->hasLevelOverridden());
+  EXPECT_TRUE(group21->isLevelOverridden());
   EXPECT_TRUE(log3->sink() == sink2);
   EXPECT_TRUE(log3->level() == Level::INFO);
 
   EXPECT_TRUE(group22->parent() == group11);
   EXPECT_TRUE(group22->sink() == sink1);
-  EXPECT_FALSE(group22->hasSinkOverridden());
+  EXPECT_FALSE(group22->isSinkOverridden());
   EXPECT_TRUE(group22->level() == Level::TRACE);
-  EXPECT_FALSE(group22->hasLevelOverridden());
+  EXPECT_FALSE(group22->isLevelOverridden());
   EXPECT_TRUE(log4->sink() == sink1);
   EXPECT_TRUE(log4->level() == Level::TRACE);
 
   EXPECT_TRUE(group31->parent() == nullptr);
   EXPECT_TRUE(group31->sink() == sink3);
-  EXPECT_TRUE(group31->hasSinkOverridden());
+  EXPECT_TRUE(group31->isSinkOverridden());
   EXPECT_TRUE(group31->level() == Level::DEBUG);
-  EXPECT_FALSE(group31->hasLevelOverridden());
+  EXPECT_FALSE(group31->isLevelOverridden());
   EXPECT_TRUE(log5->sink() == sink3);
   EXPECT_TRUE(log5->level() == Level::DEBUG);
 
   EXPECT_TRUE(group32->parent() == group21);
   EXPECT_TRUE(group32->sink() == sink2);
-  EXPECT_FALSE(group32->hasSinkOverridden());
+  EXPECT_FALSE(group32->isSinkOverridden());
   EXPECT_TRUE(group32->level() == Level::CRITICAL);
-  EXPECT_TRUE(group32->hasLevelOverridden());
+  EXPECT_TRUE(group32->isLevelOverridden());
   EXPECT_TRUE(log6->sink() == sink2);
   EXPECT_TRUE(log6->level() == Level::CRITICAL);
 
@@ -866,49 +866,49 @@ TEST_F(LoggingSystemTest, ChangeParentGroup) {
 
   EXPECT_TRUE(group11->parent() == nullptr);
   EXPECT_TRUE(group11->sink() == sink1);
-  EXPECT_FALSE(group11->hasSinkOverridden());
+  EXPECT_FALSE(group11->isSinkOverridden());
   EXPECT_TRUE(group11->level() == Level::TRACE);
-  EXPECT_FALSE(group11->hasLevelOverridden());
+  EXPECT_FALSE(group11->isLevelOverridden());
   EXPECT_TRUE(log1->sink() == sink1);
   EXPECT_TRUE(log1->level() == Level::TRACE);
 
   EXPECT_TRUE(group12->parent() == nullptr);
   EXPECT_TRUE(group12->sink() == sink2);
-  EXPECT_FALSE(group12->hasSinkOverridden());
+  EXPECT_FALSE(group12->isSinkOverridden());
   EXPECT_TRUE(group12->level() == Level::DEBUG);
-  EXPECT_FALSE(group12->hasLevelOverridden());
+  EXPECT_FALSE(group12->isLevelOverridden());
   EXPECT_TRUE(log2->sink() == sink2);
   EXPECT_TRUE(log2->level() == Level::DEBUG);
 
   EXPECT_TRUE(group21->parent() == group22);
   EXPECT_TRUE(group21->sink() == sink1);
-  EXPECT_FALSE(group21->hasSinkOverridden());
+  EXPECT_FALSE(group21->isSinkOverridden());
   EXPECT_TRUE(group21->level() == Level::INFO);
-  EXPECT_TRUE(group21->hasLevelOverridden());
+  EXPECT_TRUE(group21->isLevelOverridden());
   EXPECT_TRUE(log3->sink() == sink1);
   EXPECT_TRUE(log3->level() == Level::INFO);
 
   EXPECT_TRUE(group22->parent() == group11);
   EXPECT_TRUE(group22->sink() == sink1);
-  EXPECT_FALSE(group22->hasSinkOverridden());
+  EXPECT_FALSE(group22->isSinkOverridden());
   EXPECT_TRUE(group22->level() == Level::TRACE);
-  EXPECT_FALSE(group22->hasLevelOverridden());
+  EXPECT_FALSE(group22->isLevelOverridden());
   EXPECT_TRUE(log4->sink() == sink1);
   EXPECT_TRUE(log4->level() == Level::TRACE);
 
   EXPECT_TRUE(group31->parent() == nullptr);
   EXPECT_TRUE(group31->sink() == sink3);
-  EXPECT_TRUE(group31->hasSinkOverridden());
+  EXPECT_TRUE(group31->isSinkOverridden());
   EXPECT_TRUE(group31->level() == Level::DEBUG);
-  EXPECT_FALSE(group31->hasLevelOverridden());
+  EXPECT_FALSE(group31->isLevelOverridden());
   EXPECT_TRUE(log5->sink() == sink3);
   EXPECT_TRUE(log5->level() == Level::DEBUG);
 
   EXPECT_TRUE(group32->parent() == group21);
   EXPECT_TRUE(group32->sink() == sink1);
-  EXPECT_FALSE(group32->hasSinkOverridden());
+  EXPECT_FALSE(group32->isSinkOverridden());
   EXPECT_TRUE(group32->level() == Level::CRITICAL);
-  EXPECT_TRUE(group32->hasLevelOverridden());
+  EXPECT_TRUE(group32->isLevelOverridden());
   EXPECT_TRUE(log6->sink() == sink1);
   EXPECT_TRUE(log6->level() == Level::CRITICAL);
 }
@@ -945,9 +945,9 @@ TEST_F(LoggingSystemTest, ChangeLevelOfLogger) {
   //  Level:   @1=I  D
 
   EXPECT_TRUE(log1->level() == Level::INFO);  // g1
-  EXPECT_FALSE(log1->hasLevelOverridden());
+  EXPECT_FALSE(log1->isLevelOverridden());
   EXPECT_TRUE(log2->level() == Level::DEBUG);  // own
-  EXPECT_TRUE(log2->hasLevelOverridden());
+  EXPECT_TRUE(log2->isLevelOverridden());
 
   /// @When change level of loggers
   system_->setLevelOfLogger("Log1", Level::WARN);
@@ -960,9 +960,9 @@ TEST_F(LoggingSystemTest, ChangeLevelOfLogger) {
   //           ^     ^
 
   EXPECT_TRUE(log1->level() == Level::WARN);  // *own
-  EXPECT_TRUE(log1->hasLevelOverridden());
+  EXPECT_TRUE(log1->isLevelOverridden());
   EXPECT_TRUE(log2->level() == Level::ERROR);  // *own
-  EXPECT_TRUE(log2->hasLevelOverridden());
+  EXPECT_TRUE(log2->isLevelOverridden());
 
   /// @When change level of loggers
   system_->setLevelOfGroup("group1", Level::CRITICAL);
@@ -984,9 +984,9 @@ TEST_F(LoggingSystemTest, ChangeLevelOfLogger) {
   //           ^     ^
 
   EXPECT_TRUE(log1->level() == Level::CRITICAL);  // *g1
-  EXPECT_FALSE(log1->hasLevelOverridden());
+  EXPECT_FALSE(log1->isLevelOverridden());
   EXPECT_TRUE(log2->level() == Level::CRITICAL);  // *g1
-  EXPECT_FALSE(log2->hasLevelOverridden());
+  EXPECT_FALSE(log2->isLevelOverridden());
 }
 
 TEST_F(LoggingSystemTest, ChangeSinkOfLogger) {
@@ -1036,9 +1036,9 @@ TEST_F(LoggingSystemTest, ChangeSinkOfLogger) {
   //  Level:   @1=S1  S2
 
   EXPECT_TRUE(log1->sink() == sink1);  // g1
-  EXPECT_FALSE(log1->hasSinkOverridden());
+  EXPECT_FALSE(log1->isSinkOverridden());
   EXPECT_TRUE(log2->sink() == sink2);  // own
-  EXPECT_TRUE(log2->hasSinkOverridden());
+  EXPECT_TRUE(log2->isSinkOverridden());
 
   /// @When change sink of loggers
   system_->setSinkOfLogger("Log1", "sink3");
@@ -1051,9 +1051,9 @@ TEST_F(LoggingSystemTest, ChangeSinkOfLogger) {
   //           ^     ^
 
   EXPECT_TRUE(log1->sink() == sink3);  // *own
-  EXPECT_TRUE(log1->hasSinkOverridden());
+  EXPECT_TRUE(log1->isSinkOverridden());
   EXPECT_TRUE(log2->sink() == sink4);  // *own
-  EXPECT_TRUE(log2->hasSinkOverridden());
+  EXPECT_TRUE(log2->isSinkOverridden());
 
   /// @When change sink of loggers
   system_->setSinkOfGroup("group1", "sink5");
@@ -1075,9 +1075,9 @@ TEST_F(LoggingSystemTest, ChangeSinkOfLogger) {
   //           ^     ^
 
   EXPECT_TRUE(log1->sink() == sink5);  // *g1
-  EXPECT_FALSE(log1->hasSinkOverridden());
+  EXPECT_FALSE(log1->isSinkOverridden());
   EXPECT_TRUE(log2->sink() == sink5);  // *g1
-  EXPECT_FALSE(log2->hasSinkOverridden());
+  EXPECT_FALSE(log2->isSinkOverridden());
 }
 
 TEST_F(LoggingSystemTest, ChangeGroupOfLogger) {
@@ -1127,15 +1127,15 @@ TEST_F(LoggingSystemTest, ChangeGroupOfLogger) {
 
   EXPECT_TRUE(log1->group() == group1);
   EXPECT_TRUE(log1->sink() == sink1);
-  EXPECT_FALSE(log1->hasSinkOverridden());
+  EXPECT_FALSE(log1->isSinkOverridden());
   EXPECT_TRUE(log1->level() == Level::TRACE);
-  EXPECT_FALSE(log1->hasLevelOverridden());
+  EXPECT_FALSE(log1->isLevelOverridden());
 
   EXPECT_TRUE(log2->group() == group1);
   EXPECT_TRUE(log2->sink() == sink3);
-  EXPECT_TRUE(log2->hasSinkOverridden());
+  EXPECT_TRUE(log2->isSinkOverridden());
   EXPECT_TRUE(log2->level() == Level::CRITICAL);
-  EXPECT_TRUE(log2->hasLevelOverridden());
+  EXPECT_TRUE(log2->isLevelOverridden());
 
   /// @When change group of loggers
   system_->setGroupOfLogger("Log1", "second");
@@ -1150,13 +1150,13 @@ TEST_F(LoggingSystemTest, ChangeGroupOfLogger) {
 
   EXPECT_TRUE(log1->group() == group2);
   EXPECT_TRUE(log1->sink() == sink2);
-  EXPECT_FALSE(log1->hasSinkOverridden());
+  EXPECT_FALSE(log1->isSinkOverridden());
   EXPECT_TRUE(log1->level() == Level::DEBUG);
-  EXPECT_FALSE(log1->hasLevelOverridden());
+  EXPECT_FALSE(log1->isLevelOverridden());
 
   EXPECT_TRUE(log2->group() == group2);
   EXPECT_TRUE(log2->sink() == sink3);
-  EXPECT_TRUE(log2->hasSinkOverridden());
+  EXPECT_TRUE(log2->isSinkOverridden());
   EXPECT_TRUE(log2->level() == Level::CRITICAL);
-  EXPECT_TRUE(log2->hasLevelOverridden());
+  EXPECT_TRUE(log2->isLevelOverridden());
 }

--- a/test/unit/logging_system_test.cpp
+++ b/test/unit/logging_system_test.cpp
@@ -235,37 +235,37 @@ TEST_F(LoggingSystemTest, ChangeLevelOfGroup) {
 
   auto expect_initial_state = [&] {
     EXPECT_TRUE(group1->level() == Level::INFO);
-    EXPECT_TRUE(group1->hasLevelOverriden());
+    EXPECT_FALSE(group1->hasLevelOverridden());
 
     EXPECT_TRUE(group2->level() == group1->level());
-    EXPECT_FALSE(group2->hasLevelOverriden());
+    EXPECT_FALSE(group2->hasLevelOverridden());
 
     EXPECT_TRUE(group3->level() == Level::WARN);
-    EXPECT_TRUE(group3->hasLevelOverriden());
+    EXPECT_TRUE(group3->hasLevelOverridden());
 
     EXPECT_TRUE(log1->level() == Level::INFO);
     EXPECT_TRUE(log1->level() == group2->level());
-    EXPECT_FALSE(log1->hasLevelOverriden());
+    EXPECT_FALSE(log1->hasLevelOverridden());
 
     EXPECT_TRUE(log2->level() == Level::TRACE);
     EXPECT_TRUE(log2->level() != group1->level());
-    EXPECT_TRUE(log2->hasLevelOverriden());
+    EXPECT_TRUE(log2->hasLevelOverridden());
 
     EXPECT_TRUE(log3->level() == Level::INFO);
     EXPECT_TRUE(log3->level() == group2->level());
-    EXPECT_FALSE(log3->hasLevelOverriden());
+    EXPECT_FALSE(log3->hasLevelOverridden());
 
     EXPECT_TRUE(log4->level() == Level::DEBUG);
     EXPECT_TRUE(log4->level() != group2->level());
-    EXPECT_TRUE(log4->hasLevelOverriden());
+    EXPECT_TRUE(log4->hasLevelOverridden());
 
     EXPECT_TRUE(log5->level() == Level::WARN);
     EXPECT_TRUE(log5->level() == group3->level());
-    EXPECT_FALSE(log5->hasLevelOverriden());
+    EXPECT_FALSE(log5->hasLevelOverridden());
 
     EXPECT_TRUE(log6->level() == Level::VERBOSE);
     EXPECT_TRUE(log6->level() != group3->level());
-    EXPECT_TRUE(log6->hasLevelOverriden());
+    EXPECT_TRUE(log6->hasLevelOverridden());
   };
 
   /// @Given beginning state of groups
@@ -295,25 +295,27 @@ TEST_F(LoggingSystemTest, ChangeLevelOfGroup) {
   //  Level:   @1=C  T     @2=C  D     @3=W  V
   //              ^           ^
 
+  // Properties not overridden because group doesn't have parent
   EXPECT_TRUE(group1->level() == Level::CRITICAL);  // *own
-  EXPECT_TRUE(group1->hasLevelOverriden());
+  EXPECT_FALSE(group1->hasLevelOverridden());
   EXPECT_TRUE(group2->level() == Level::CRITICAL);  // *g1
-  EXPECT_FALSE(group2->hasLevelOverriden());
+  EXPECT_FALSE(
+      group2->hasLevelOverridden());  // no overridden because no parent
   EXPECT_TRUE(group3->level() == Level::WARN);  // own
-  EXPECT_TRUE(group3->hasLevelOverriden());
+  EXPECT_TRUE(group3->hasLevelOverridden());
 
   EXPECT_TRUE(log1->level() == Level::CRITICAL);  // *g1
-  EXPECT_FALSE(log1->hasLevelOverriden());
+  EXPECT_FALSE(log1->hasLevelOverridden());
   EXPECT_TRUE(log2->level() == Level::TRACE);  // own
-  EXPECT_TRUE(log2->hasLevelOverriden());
+  EXPECT_TRUE(log2->hasLevelOverridden());
   EXPECT_TRUE(log3->level() == Level::CRITICAL);  // *g2<-g1
-  EXPECT_FALSE(log3->hasLevelOverriden());
+  EXPECT_FALSE(log3->hasLevelOverridden());
   EXPECT_TRUE(log4->level() == Level::DEBUG);  // own
-  EXPECT_TRUE(log4->hasLevelOverriden());
+  EXPECT_TRUE(log4->hasLevelOverridden());
   EXPECT_TRUE(log5->level() == Level::WARN);  // g3
-  EXPECT_FALSE(log5->hasLevelOverriden());
+  EXPECT_FALSE(log5->hasLevelOverridden());
   EXPECT_TRUE(log6->level() == Level::VERBOSE);  // own
-  EXPECT_TRUE(log6->hasLevelOverriden());
+  EXPECT_TRUE(log6->hasLevelOverridden());
 
   /// @When coming back previous group's level
   system_->setLevelOfGroup("first", Level::INFO);
@@ -337,24 +339,24 @@ TEST_F(LoggingSystemTest, ChangeLevelOfGroup) {
   //                       ^
 
   EXPECT_TRUE(group1->level() == Level::INFO);  // own
-  EXPECT_TRUE(group1->hasLevelOverriden());
+  EXPECT_FALSE(group1->hasLevelOverridden());
   EXPECT_TRUE(group2->level() == Level::CRITICAL);  // *own
-  EXPECT_TRUE(group2->hasLevelOverriden());
+  EXPECT_TRUE(group2->hasLevelOverridden());
   EXPECT_TRUE(group3->level() == Level::WARN);  // own
-  EXPECT_TRUE(group3->hasLevelOverriden());
+  EXPECT_TRUE(group3->hasLevelOverridden());
 
   EXPECT_TRUE(log1->level() == Level::INFO);  // g1
-  EXPECT_FALSE(log1->hasLevelOverriden());
+  EXPECT_FALSE(log1->hasLevelOverridden());
   EXPECT_TRUE(log2->level() == Level::TRACE);  // own
-  EXPECT_TRUE(log2->hasLevelOverriden());
+  EXPECT_TRUE(log2->hasLevelOverridden());
   EXPECT_TRUE(log3->level() == Level::CRITICAL);  // *g2
-  EXPECT_FALSE(log3->hasLevelOverriden());
+  EXPECT_FALSE(log3->hasLevelOverridden());
   EXPECT_TRUE(log4->level() == Level::DEBUG);  // own
-  EXPECT_TRUE(log4->hasLevelOverriden());
+  EXPECT_TRUE(log4->hasLevelOverridden());
   EXPECT_TRUE(log5->level() == Level::WARN);  // g3
-  EXPECT_FALSE(log5->hasLevelOverriden());
+  EXPECT_FALSE(log5->hasLevelOverridden());
   EXPECT_TRUE(log6->level() == Level::VERBOSE);  // own
-  EXPECT_TRUE(log6->hasLevelOverriden());
+  EXPECT_TRUE(log6->hasLevelOverridden());
 
   /// @When come back dependent of top group
   system_->resetLevelOfGroup("second");
@@ -418,37 +420,37 @@ TEST_F(LoggingSystemTest, ChangeSinkOfGroup) {
 
   auto expect_initial_state = [&] {
     EXPECT_TRUE(group1->sink() == sink1);
-    EXPECT_TRUE(group1->hasSinkOverriden());
+    EXPECT_FALSE(group1->hasSinkOverridden());
 
     EXPECT_TRUE(group2->sink() == group1->sink());
-    EXPECT_FALSE(group2->hasSinkOverriden());
+    EXPECT_FALSE(group2->hasSinkOverridden());
 
     EXPECT_TRUE(group3->sink() == sink2);
-    EXPECT_TRUE(group3->hasSinkOverriden());
+    EXPECT_TRUE(group3->hasSinkOverridden());
 
     EXPECT_TRUE(log1->sink() == sink1);
     EXPECT_TRUE(log1->sink() == group2->sink());
-    EXPECT_FALSE(log1->hasSinkOverriden());
+    EXPECT_FALSE(log1->hasSinkOverridden());
 
     EXPECT_TRUE(log2->sink() == sink3);
     EXPECT_TRUE(log2->sink() != group1->sink());
-    EXPECT_TRUE(log2->hasSinkOverriden());
+    EXPECT_TRUE(log2->hasSinkOverridden());
 
     EXPECT_TRUE(log3->sink() == sink1);
     EXPECT_TRUE(log3->sink() == group2->sink());
-    EXPECT_FALSE(log3->hasSinkOverriden());
+    EXPECT_FALSE(log3->hasSinkOverridden());
 
     EXPECT_TRUE(log4->sink() == sink4);
     EXPECT_TRUE(log4->sink() != group2->sink());
-    EXPECT_TRUE(log4->hasSinkOverriden());
+    EXPECT_TRUE(log4->hasSinkOverridden());
 
     EXPECT_TRUE(log5->sink() == sink2);
     EXPECT_TRUE(log5->sink() == group3->sink());
-    EXPECT_FALSE(log5->hasSinkOverriden());
+    EXPECT_FALSE(log5->hasSinkOverridden());
 
     EXPECT_TRUE(log6->sink() == sink5);
     EXPECT_TRUE(log6->sink() != group3->sink());
-    EXPECT_TRUE(log6->hasSinkOverriden());
+    EXPECT_TRUE(log6->hasSinkOverridden());
   };
 
   /// @Given beginning state of groups
@@ -479,24 +481,24 @@ TEST_F(LoggingSystemTest, ChangeSinkOfGroup) {
   //              ^           ^
 
   EXPECT_TRUE(group1->sink() == sink6);  // *own
-  EXPECT_TRUE(group1->hasSinkOverriden());
+  EXPECT_FALSE(group1->hasSinkOverridden());
   EXPECT_TRUE(group2->sink() == sink6);  // *g1
-  EXPECT_FALSE(group2->hasSinkOverriden());
+  EXPECT_FALSE(group2->hasSinkOverridden());
   EXPECT_TRUE(group3->sink() == sink2);  // own
-  EXPECT_TRUE(group3->hasSinkOverriden());
+  EXPECT_TRUE(group3->hasSinkOverridden());
 
   EXPECT_TRUE(log1->sink() == sink6);  // *g1
-  EXPECT_FALSE(log1->hasSinkOverriden());
+  EXPECT_FALSE(log1->hasSinkOverridden());
   EXPECT_TRUE(log2->sink() == sink3);  // own
-  EXPECT_TRUE(log2->hasSinkOverriden());
+  EXPECT_TRUE(log2->hasSinkOverridden());
   EXPECT_TRUE(log3->sink() == sink6);  // *g2<-g1
-  EXPECT_FALSE(log3->hasSinkOverriden());
+  EXPECT_FALSE(log3->hasSinkOverridden());
   EXPECT_TRUE(log4->sink() == sink4);  // own
-  EXPECT_TRUE(log4->hasSinkOverriden());
+  EXPECT_TRUE(log4->hasSinkOverridden());
   EXPECT_TRUE(log5->sink() == sink2);  // g3
-  EXPECT_FALSE(log5->hasSinkOverriden());
+  EXPECT_FALSE(log5->hasSinkOverridden());
   EXPECT_TRUE(log6->sink() == sink5);  // own
-  EXPECT_TRUE(log6->hasSinkOverriden());
+  EXPECT_TRUE(log6->hasSinkOverridden());
 
   /// @When come back sink of top group
   system_->setSinkOfGroup("first", "sink1");
@@ -520,24 +522,24 @@ TEST_F(LoggingSystemTest, ChangeSinkOfGroup) {
   //                       ^
 
   EXPECT_TRUE(group1->sink() == sink1);  // own
-  EXPECT_TRUE(group1->hasSinkOverriden());
+  EXPECT_FALSE(group1->hasSinkOverridden());
   EXPECT_TRUE(group2->sink() == sink6);  // *own
-  EXPECT_TRUE(group2->hasSinkOverriden());
+  EXPECT_TRUE(group2->hasSinkOverridden());
   EXPECT_TRUE(group3->sink() == sink2);  // own
-  EXPECT_TRUE(group3->hasSinkOverriden());
+  EXPECT_TRUE(group3->hasSinkOverridden());
 
   EXPECT_TRUE(log1->sink() == sink1);  // g1
-  EXPECT_FALSE(log1->hasSinkOverriden());
+  EXPECT_FALSE(log1->hasSinkOverridden());
   EXPECT_TRUE(log2->sink() == sink3);  // own
-  EXPECT_TRUE(log2->hasSinkOverriden());
+  EXPECT_TRUE(log2->hasSinkOverridden());
   EXPECT_TRUE(log3->sink() == sink6);  // *g2
-  EXPECT_FALSE(log3->hasSinkOverriden());
+  EXPECT_FALSE(log3->hasSinkOverridden());
   EXPECT_TRUE(log4->sink() == sink4);  // own
-  EXPECT_TRUE(log4->hasSinkOverriden());
+  EXPECT_TRUE(log4->hasSinkOverridden());
   EXPECT_TRUE(log5->sink() == sink2);  // g3
-  EXPECT_FALSE(log5->hasSinkOverriden());
+  EXPECT_FALSE(log5->hasSinkOverridden());
   EXPECT_TRUE(log6->sink() == sink5);  // own
-  EXPECT_TRUE(log6->hasSinkOverriden());
+  EXPECT_TRUE(log6->hasSinkOverridden());
 
   /// @When come back dependent of top group
   system_->resetSinkOfGroup("second");
@@ -553,15 +555,12 @@ TEST_F(LoggingSystemTest, ChangeParentGroup) {
     system.makeSink<SinkMock>("sink1");
     system.makeSink<SinkMock>("sink2");
     system.makeSink<SinkMock>("sink3");
-    system.makeSink<SinkMock>("sink4");
-    system.makeSink<SinkMock>("sink5");
-    system.makeSink<SinkMock>("sink6");
     system.makeGroup("first1", {}, "sink1", Level::TRACE);
     system.makeGroup("first2", {}, "sink2", Level::DEBUG);
     system.makeGroup("second1", "first1", {}, {});
     system.makeGroup("second2", "first1", {}, {});
-    system.makeGroup("third1", "second1", {}, {});
-    system.makeGroup("third2", "second1", {}, {});
+    system.makeGroup("third1", "second1", "sink3", {});
+    system.makeGroup("third2", "second1", {}, Level::CRITICAL);
     return Configurator::Result{};
   }));
   EXPECT_CALL(*configurator_, applyOn(_)).Times(1);
@@ -574,12 +573,6 @@ TEST_F(LoggingSystemTest, ChangeParentGroup) {
   ASSERT_TRUE(sink2 != nullptr);
   auto sink3 = system_->getSink("sink3");
   ASSERT_TRUE(sink3 != nullptr);
-  auto sink4 = system_->getSink("sink4");
-  ASSERT_TRUE(sink4 != nullptr);
-  auto sink5 = system_->getSink("sink5");
-  ASSERT_TRUE(sink5 != nullptr);
-  auto sink6 = system_->getSink("sink6");
-  ASSERT_TRUE(sink6 != nullptr);
 
   auto group11 = system_->getGroup("first1");
   ASSERT_TRUE(group11 != nullptr);
@@ -608,50 +601,6 @@ TEST_F(LoggingSystemTest, ChangeParentGroup) {
   auto log6 = system_->getLogger("Log6", "third2");
   ASSERT_TRUE(log6 != nullptr);
 
-  auto expect_initial_state = [&] {
-    EXPECT_TRUE(group11->parent() == nullptr);
-    EXPECT_TRUE(group11->sink() == sink1);
-    EXPECT_TRUE(group11->level() == Level::TRACE);
-
-    EXPECT_TRUE(group12->parent() == nullptr);
-    EXPECT_TRUE(group12->sink() == sink2);
-    EXPECT_TRUE(group12->level() == Level::DEBUG);
-
-    EXPECT_TRUE(group21->parent() == group11);
-    EXPECT_TRUE(group21->sink() == sink1);
-    EXPECT_TRUE(group21->level() == Level::TRACE);
-
-    EXPECT_TRUE(group22->parent() == group11);
-    EXPECT_TRUE(group22->sink() == sink1);
-    EXPECT_TRUE(group22->level() == Level::TRACE);
-
-    EXPECT_TRUE(group31->parent() == group21);
-    EXPECT_TRUE(group31->sink() == sink1);
-    EXPECT_TRUE(group31->level() == Level::TRACE);
-
-    EXPECT_TRUE(group32->parent() == group21);
-    EXPECT_TRUE(group32->sink() == sink1);
-    EXPECT_TRUE(group32->level() == Level::TRACE);
-
-    EXPECT_TRUE(log1->sink() == sink1);
-    EXPECT_TRUE(log1->level() == Level::TRACE);
-
-    EXPECT_TRUE(log2->sink() == sink2);
-    EXPECT_TRUE(log2->level() == Level::DEBUG);
-
-    EXPECT_TRUE(log3->sink() == sink1);
-    EXPECT_TRUE(log3->level() == Level::TRACE);
-
-    EXPECT_TRUE(log4->sink() == sink1);
-    EXPECT_TRUE(log4->level() == Level::TRACE);
-
-    EXPECT_TRUE(log5->sink() == sink1);
-    EXPECT_TRUE(log5->level() == Level::TRACE);
-
-    EXPECT_TRUE(log6->sink() == sink1);
-    EXPECT_TRUE(log6->level() == Level::TRACE);
-  };
-
   /// @Given beginning state of groups
   //    G11 -- G21 -- G31
   //        \      `- G32
@@ -660,14 +609,60 @@ TEST_F(LoggingSystemTest, ChangeParentGroup) {
   //
   //  Group:   G11    G12    G21    G22    G31    G32
   //  Parent:  -      -      G11    G11    G21    G21
-  //  Sink:    S1     S2     @11=S1 @11=S1 @21=S1 @21=S1
-  //  Level:   T      D      @11=T  G11=T  @21=T  @21=T
+  //  Sink:    S1     S2     @11=S1 @11=S1 =S3 @21=S1
+  //  Level:   T      D      @11=T  G11=T  @21=T  =C
 
   /// @Given beginning state of loggers
   //  Logger:  L1    L2    L3    L4    L5    L6
   //  Group:   G11   G12   G21   G22   G31   G32
 
-  expect_initial_state();
+  EXPECT_TRUE(group11->parent() == nullptr);
+  EXPECT_TRUE(group11->sink() == sink1);
+  EXPECT_FALSE(group11->hasSinkOverridden());
+  EXPECT_TRUE(group11->level() == Level::TRACE);
+  EXPECT_FALSE(group11->hasLevelOverridden());
+  EXPECT_TRUE(log1->sink() == sink1);
+  EXPECT_TRUE(log1->level() == Level::TRACE);
+
+  EXPECT_TRUE(group12->parent() == nullptr);
+  EXPECT_TRUE(group12->sink() == sink2);
+  EXPECT_FALSE(group12->hasSinkOverridden());
+  EXPECT_TRUE(group12->level() == Level::DEBUG);
+  EXPECT_FALSE(group12->hasLevelOverridden());
+  EXPECT_TRUE(log2->sink() == sink2);
+  EXPECT_TRUE(log2->level() == Level::DEBUG);
+
+  EXPECT_TRUE(group21->parent() == group11);
+  EXPECT_TRUE(group21->sink() == sink1);
+  EXPECT_FALSE(group21->hasSinkOverridden());
+  EXPECT_TRUE(group21->level() == Level::TRACE);
+  EXPECT_FALSE(group21->hasLevelOverridden());
+  EXPECT_TRUE(log3->sink() == sink1);
+  EXPECT_TRUE(log3->level() == Level::TRACE);
+
+  EXPECT_TRUE(group22->parent() == group11);
+  EXPECT_TRUE(group22->sink() == sink1);
+  EXPECT_FALSE(group22->hasSinkOverridden());
+  EXPECT_TRUE(group22->level() == Level::TRACE);
+  EXPECT_FALSE(group22->hasLevelOverridden());
+  EXPECT_TRUE(log4->sink() == sink1);
+  EXPECT_TRUE(log4->level() == Level::TRACE);
+
+  EXPECT_TRUE(group31->parent() == group21);
+  EXPECT_TRUE(group31->sink() == sink3);
+  EXPECT_TRUE(group31->hasSinkOverridden());
+  EXPECT_TRUE(group31->level() == Level::TRACE);
+  EXPECT_FALSE(group31->hasLevelOverridden());
+  EXPECT_TRUE(log5->sink() == sink3);
+  EXPECT_TRUE(log5->level() == Level::TRACE);
+
+  EXPECT_TRUE(group32->parent() == group21);
+  EXPECT_TRUE(group32->sink() == sink1);
+  EXPECT_FALSE(group32->hasSinkOverridden());
+  EXPECT_TRUE(group32->level() == Level::CRITICAL);
+  EXPECT_TRUE(group32->hasLevelOverridden());
+  EXPECT_TRUE(log6->sink() == sink1);
+  EXPECT_TRUE(log6->level() == Level::CRITICAL);
 
   /// @When change parent of 2-level group
   system_->setParentOfGroup("second1", "first2");
@@ -679,57 +674,57 @@ TEST_F(LoggingSystemTest, ChangeParentGroup) {
   //
   //  Group:   G11    G12    G21    G22    G31    G32
   //  Parent:  -      -      G12    G11    G21    G21
-  //  Sink:    S1     S2     @12=S2 @11=S1 @21=S2 @21=S2
-  //  Level:   T      D      @12=D  G11=T  @21=D  @21=D
-  //                  ^                ^      ^      ^
+  //  Sink:    S1     S2     @12=S2 @11=S1 =S3 @21=S2
+  //  Level:   T      D      @12=D  G11=T  @21=D  =C
+  //                  ^                ^      ^
 
   EXPECT_TRUE(group11->parent() == nullptr);
   EXPECT_TRUE(group11->sink() == sink1);
-  EXPECT_TRUE(group11->hasSinkOverriden());
+  EXPECT_FALSE(group11->hasSinkOverridden());
   EXPECT_TRUE(group11->level() == Level::TRACE);
-  EXPECT_TRUE(group11->hasLevelOverriden());
+  EXPECT_FALSE(group11->hasLevelOverridden());
   EXPECT_TRUE(log1->sink() == sink1);
   EXPECT_TRUE(log1->level() == Level::TRACE);
 
   EXPECT_TRUE(group12->parent() == nullptr);
   EXPECT_TRUE(group12->sink() == sink2);
-  EXPECT_TRUE(group12->hasSinkOverriden());
+  EXPECT_FALSE(group12->hasSinkOverridden());
   EXPECT_TRUE(group12->level() == Level::DEBUG);
-  EXPECT_TRUE(group12->hasLevelOverriden());
+  EXPECT_FALSE(group12->hasLevelOverridden());
   EXPECT_TRUE(log2->sink() == sink2);
   EXPECT_TRUE(log2->level() == Level::DEBUG);
 
   EXPECT_TRUE(group21->parent() == group12);
   EXPECT_TRUE(group21->sink() == sink2);
-  EXPECT_FALSE(group21->hasSinkOverriden());
+  EXPECT_FALSE(group21->hasSinkOverridden());
   EXPECT_TRUE(group21->level() == Level::DEBUG);
-  EXPECT_FALSE(group21->hasLevelOverriden());
+  EXPECT_FALSE(group21->hasLevelOverridden());
   EXPECT_TRUE(log3->sink() == sink2);
   EXPECT_TRUE(log3->level() == Level::DEBUG);
 
   EXPECT_TRUE(group22->parent() == group11);
   EXPECT_TRUE(group22->sink() == sink1);
-  EXPECT_FALSE(group22->hasSinkOverriden());
+  EXPECT_FALSE(group22->hasSinkOverridden());
   EXPECT_TRUE(group22->level() == Level::TRACE);
-  EXPECT_FALSE(group22->hasLevelOverriden());
+  EXPECT_FALSE(group22->hasLevelOverridden());
   EXPECT_TRUE(log4->sink() == sink1);
   EXPECT_TRUE(log4->level() == Level::TRACE);
 
   EXPECT_TRUE(group31->parent() == group21);
-  EXPECT_TRUE(group31->sink() == sink2);
-  EXPECT_FALSE(group31->hasSinkOverriden());
+  EXPECT_TRUE(group31->sink() == sink3);
+  EXPECT_TRUE(group31->hasSinkOverridden());
   EXPECT_TRUE(group31->level() == Level::DEBUG);
-  EXPECT_FALSE(group31->hasLevelOverriden());
-  EXPECT_TRUE(log5->sink() == sink2);
+  EXPECT_FALSE(group31->hasLevelOverridden());
+  EXPECT_TRUE(log5->sink() == sink3);
   EXPECT_TRUE(log5->level() == Level::DEBUG);
 
   EXPECT_TRUE(group32->parent() == group21);
   EXPECT_TRUE(group32->sink() == sink2);
-  EXPECT_FALSE(group32->hasSinkOverriden());
-  EXPECT_TRUE(group32->level() == Level::DEBUG);
-  EXPECT_FALSE(group32->hasLevelOverriden());
+  EXPECT_FALSE(group32->hasSinkOverridden());
+  EXPECT_TRUE(group32->level() == Level::CRITICAL);
+  EXPECT_TRUE(group32->hasLevelOverridden());
   EXPECT_TRUE(log6->sink() == sink2);
-  EXPECT_TRUE(log6->level() == Level::DEBUG);
+  EXPECT_TRUE(log6->level() == Level::CRITICAL);
 
   /// @When unset parent of group
   system_->unsetParentOfGroup("third1");
@@ -741,60 +736,60 @@ TEST_F(LoggingSystemTest, ChangeParentGroup) {
   //
   //  Group:   G11    G12    G21    G22    G31    G32
   //  Parent:  -      -      G12    G11    -      G21
-  //  Sink:    S1     S2     @12=S2 @11=S1 S2     @21=S2
-  //  Level:   T      D      @12=D  G11=T  D      @21=D
+  //  Sink:    S1     S2     @12=S2 @11=S1 =S3    @21=S2
+  //  Level:   T      D      @12=D  G11=T  D      =C
   //                                       ^
 
   EXPECT_TRUE(group11->parent() == nullptr);
   EXPECT_TRUE(group11->sink() == sink1);
-  EXPECT_TRUE(group11->hasSinkOverriden());
+  EXPECT_FALSE(group11->hasSinkOverridden());
   EXPECT_TRUE(group11->level() == Level::TRACE);
-  EXPECT_TRUE(group11->hasLevelOverriden());
+  EXPECT_FALSE(group11->hasLevelOverridden());
   EXPECT_TRUE(log1->sink() == sink1);
   EXPECT_TRUE(log1->level() == Level::TRACE);
 
   EXPECT_TRUE(group12->parent() == nullptr);
   EXPECT_TRUE(group12->sink() == sink2);
-  EXPECT_TRUE(group12->hasSinkOverriden());
+  EXPECT_FALSE(group12->hasSinkOverridden());
   EXPECT_TRUE(group12->level() == Level::DEBUG);
-  EXPECT_TRUE(group12->hasLevelOverriden());
+  EXPECT_FALSE(group12->hasLevelOverridden());
   EXPECT_TRUE(log2->sink() == sink2);
   EXPECT_TRUE(log2->level() == Level::DEBUG);
 
   EXPECT_TRUE(group21->parent() == group12);
   EXPECT_TRUE(group21->sink() == sink2);
-  EXPECT_FALSE(group21->hasSinkOverriden());
+  EXPECT_FALSE(group21->hasSinkOverridden());
   EXPECT_TRUE(group21->level() == Level::DEBUG);
-  EXPECT_FALSE(group21->hasLevelOverriden());
+  EXPECT_FALSE(group21->hasLevelOverridden());
   EXPECT_TRUE(log3->sink() == sink2);
   EXPECT_TRUE(log3->level() == Level::DEBUG);
 
   EXPECT_TRUE(group22->parent() == group11);
   EXPECT_TRUE(group22->sink() == sink1);
-  EXPECT_FALSE(group22->hasSinkOverriden());
+  EXPECT_FALSE(group22->hasSinkOverridden());
   EXPECT_TRUE(group22->level() == Level::TRACE);
-  EXPECT_FALSE(group22->hasLevelOverriden());
+  EXPECT_FALSE(group22->hasLevelOverridden());
   EXPECT_TRUE(log4->sink() == sink1);
   EXPECT_TRUE(log4->level() == Level::TRACE);
 
   EXPECT_TRUE(group31->parent() == nullptr);
-  EXPECT_TRUE(group31->sink() == sink2);
-  EXPECT_TRUE(group31->hasSinkOverriden());
+  EXPECT_TRUE(group31->sink() == sink3);
+  EXPECT_TRUE(group31->hasSinkOverridden());
   EXPECT_TRUE(group31->level() == Level::DEBUG);
-  EXPECT_TRUE(group31->hasLevelOverriden());
-  EXPECT_TRUE(log5->sink() == sink2);
+  EXPECT_FALSE(group31->hasLevelOverridden());
+  EXPECT_TRUE(log5->sink() == sink3);
   EXPECT_TRUE(log5->level() == Level::DEBUG);
 
   EXPECT_TRUE(group32->parent() == group21);
   EXPECT_TRUE(group32->sink() == sink2);
-  EXPECT_FALSE(group32->hasSinkOverriden());
-  EXPECT_TRUE(group32->level() == Level::DEBUG);
-  EXPECT_FALSE(group32->hasLevelOverriden());
+  EXPECT_FALSE(group32->hasSinkOverridden());
+  EXPECT_TRUE(group32->level() == Level::CRITICAL);
+  EXPECT_TRUE(group32->hasLevelOverridden());
   EXPECT_TRUE(log6->sink() == sink2);
-  EXPECT_TRUE(log6->level() == Level::DEBUG);
+  EXPECT_TRUE(log6->level() == Level::CRITICAL);
 
   /// @When change level of group
-  system_->setLevelOfGroup("second1", Level::CRITICAL);
+  system_->setLevelOfGroup("second1", Level::INFO);
 
   /// @Then is have next state of groups
   //    G11 -- G22
@@ -803,55 +798,55 @@ TEST_F(LoggingSystemTest, ChangeParentGroup) {
   //
   //  Group:   G11    G12    G21    G22    G31    G32
   //  Parent:  -      -      G12    G11    -      G21
-  //  Sink:    S1     S2     @12=S2 @11=S1 S2     @21=S2
-  //  Level:   T      D      C      G11=T  D      @21=C
-  //                         ^                       ^
+  //  Sink:    S1     S2     @12=S2 @11=S1 =S3     @21=S2
+  //  Level:   T      D      I      G11=T  D      =C
+  //                         ^
 
   EXPECT_TRUE(group11->parent() == nullptr);
   EXPECT_TRUE(group11->sink() == sink1);
-  EXPECT_TRUE(group11->hasSinkOverriden());
+  EXPECT_FALSE(group11->hasSinkOverridden());
   EXPECT_TRUE(group11->level() == Level::TRACE);
-  EXPECT_TRUE(group11->hasLevelOverriden());
+  EXPECT_FALSE(group11->hasLevelOverridden());
   EXPECT_TRUE(log1->sink() == sink1);
   EXPECT_TRUE(log1->level() == Level::TRACE);
 
   EXPECT_TRUE(group12->parent() == nullptr);
   EXPECT_TRUE(group12->sink() == sink2);
-  EXPECT_TRUE(group12->hasSinkOverriden());
+  EXPECT_FALSE(group12->hasSinkOverridden());
   EXPECT_TRUE(group12->level() == Level::DEBUG);
-  EXPECT_TRUE(group12->hasLevelOverriden());
+  EXPECT_FALSE(group12->hasLevelOverridden());
   EXPECT_TRUE(log2->sink() == sink2);
   EXPECT_TRUE(log2->level() == Level::DEBUG);
 
   EXPECT_TRUE(group21->parent() == group12);
   EXPECT_TRUE(group21->sink() == sink2);
-  EXPECT_FALSE(group21->hasSinkOverriden());
-  EXPECT_TRUE(group21->level() == Level::CRITICAL);
-  EXPECT_TRUE(group21->hasLevelOverriden());
+  EXPECT_FALSE(group21->hasSinkOverridden());
+  EXPECT_TRUE(group21->level() == Level::INFO);
+  EXPECT_TRUE(group21->hasLevelOverridden());
   EXPECT_TRUE(log3->sink() == sink2);
-  EXPECT_TRUE(log3->level() == Level::CRITICAL);
+  EXPECT_TRUE(log3->level() == Level::INFO);
 
   EXPECT_TRUE(group22->parent() == group11);
   EXPECT_TRUE(group22->sink() == sink1);
-  EXPECT_FALSE(group22->hasSinkOverriden());
+  EXPECT_FALSE(group22->hasSinkOverridden());
   EXPECT_TRUE(group22->level() == Level::TRACE);
-  EXPECT_FALSE(group22->hasLevelOverriden());
+  EXPECT_FALSE(group22->hasLevelOverridden());
   EXPECT_TRUE(log4->sink() == sink1);
   EXPECT_TRUE(log4->level() == Level::TRACE);
 
   EXPECT_TRUE(group31->parent() == nullptr);
-  EXPECT_TRUE(group31->sink() == sink2);
-  EXPECT_TRUE(group31->hasSinkOverriden());
+  EXPECT_TRUE(group31->sink() == sink3);
+  EXPECT_TRUE(group31->hasSinkOverridden());
   EXPECT_TRUE(group31->level() == Level::DEBUG);
-  EXPECT_TRUE(group31->hasLevelOverriden());
-  EXPECT_TRUE(log5->sink() == sink2);
+  EXPECT_FALSE(group31->hasLevelOverridden());
+  EXPECT_TRUE(log5->sink() == sink3);
   EXPECT_TRUE(log5->level() == Level::DEBUG);
 
   EXPECT_TRUE(group32->parent() == group21);
   EXPECT_TRUE(group32->sink() == sink2);
-  EXPECT_FALSE(group32->hasSinkOverriden());
+  EXPECT_FALSE(group32->hasSinkOverridden());
   EXPECT_TRUE(group32->level() == Level::CRITICAL);
-  EXPECT_FALSE(group32->hasLevelOverriden());
+  EXPECT_TRUE(group32->hasLevelOverridden());
   EXPECT_TRUE(log6->sink() == sink2);
   EXPECT_TRUE(log6->level() == Level::CRITICAL);
 
@@ -871,49 +866,49 @@ TEST_F(LoggingSystemTest, ChangeParentGroup) {
 
   EXPECT_TRUE(group11->parent() == nullptr);
   EXPECT_TRUE(group11->sink() == sink1);
-  EXPECT_TRUE(group11->hasSinkOverriden());
+  EXPECT_FALSE(group11->hasSinkOverridden());
   EXPECT_TRUE(group11->level() == Level::TRACE);
-  EXPECT_TRUE(group11->hasLevelOverriden());
+  EXPECT_FALSE(group11->hasLevelOverridden());
   EXPECT_TRUE(log1->sink() == sink1);
   EXPECT_TRUE(log1->level() == Level::TRACE);
 
   EXPECT_TRUE(group12->parent() == nullptr);
   EXPECT_TRUE(group12->sink() == sink2);
-  EXPECT_TRUE(group12->hasSinkOverriden());
+  EXPECT_FALSE(group12->hasSinkOverridden());
   EXPECT_TRUE(group12->level() == Level::DEBUG);
-  EXPECT_TRUE(group12->hasLevelOverriden());
+  EXPECT_FALSE(group12->hasLevelOverridden());
   EXPECT_TRUE(log2->sink() == sink2);
   EXPECT_TRUE(log2->level() == Level::DEBUG);
 
   EXPECT_TRUE(group21->parent() == group22);
   EXPECT_TRUE(group21->sink() == sink1);
-  EXPECT_FALSE(group21->hasSinkOverriden());
-  EXPECT_TRUE(group21->level() == Level::CRITICAL);
-  EXPECT_TRUE(group21->hasLevelOverriden());
+  EXPECT_FALSE(group21->hasSinkOverridden());
+  EXPECT_TRUE(group21->level() == Level::INFO);
+  EXPECT_TRUE(group21->hasLevelOverridden());
   EXPECT_TRUE(log3->sink() == sink1);
-  EXPECT_TRUE(log3->level() == Level::CRITICAL);
+  EXPECT_TRUE(log3->level() == Level::INFO);
 
   EXPECT_TRUE(group22->parent() == group11);
   EXPECT_TRUE(group22->sink() == sink1);
-  EXPECT_FALSE(group22->hasSinkOverriden());
+  EXPECT_FALSE(group22->hasSinkOverridden());
   EXPECT_TRUE(group22->level() == Level::TRACE);
-  EXPECT_FALSE(group22->hasLevelOverriden());
+  EXPECT_FALSE(group22->hasLevelOverridden());
   EXPECT_TRUE(log4->sink() == sink1);
   EXPECT_TRUE(log4->level() == Level::TRACE);
 
   EXPECT_TRUE(group31->parent() == nullptr);
-  EXPECT_TRUE(group31->sink() == sink2);
-  EXPECT_TRUE(group31->hasSinkOverriden());
+  EXPECT_TRUE(group31->sink() == sink3);
+  EXPECT_TRUE(group31->hasSinkOverridden());
   EXPECT_TRUE(group31->level() == Level::DEBUG);
-  EXPECT_TRUE(group31->hasLevelOverriden());
-  EXPECT_TRUE(log5->sink() == sink2);
+  EXPECT_FALSE(group31->hasLevelOverridden());
+  EXPECT_TRUE(log5->sink() == sink3);
   EXPECT_TRUE(log5->level() == Level::DEBUG);
 
   EXPECT_TRUE(group32->parent() == group21);
   EXPECT_TRUE(group32->sink() == sink1);
-  EXPECT_FALSE(group32->hasSinkOverriden());
+  EXPECT_FALSE(group32->hasSinkOverridden());
   EXPECT_TRUE(group32->level() == Level::CRITICAL);
-  EXPECT_FALSE(group32->hasLevelOverriden());
+  EXPECT_TRUE(group32->hasLevelOverridden());
   EXPECT_TRUE(log6->sink() == sink1);
   EXPECT_TRUE(log6->level() == Level::CRITICAL);
 }
@@ -950,9 +945,9 @@ TEST_F(LoggingSystemTest, ChangeLevelOfLogger) {
   //  Level:   @1=I  D
 
   EXPECT_TRUE(log1->level() == Level::INFO);  // g1
-  EXPECT_FALSE(log1->hasLevelOverriden());
+  EXPECT_FALSE(log1->hasLevelOverridden());
   EXPECT_TRUE(log2->level() == Level::DEBUG);  // own
-  EXPECT_TRUE(log2->hasLevelOverriden());
+  EXPECT_TRUE(log2->hasLevelOverridden());
 
   /// @When change level of loggers
   system_->setLevelOfLogger("Log1", Level::WARN);
@@ -965,9 +960,9 @@ TEST_F(LoggingSystemTest, ChangeLevelOfLogger) {
   //           ^     ^
 
   EXPECT_TRUE(log1->level() == Level::WARN);  // *own
-  EXPECT_TRUE(log1->hasLevelOverriden());
+  EXPECT_TRUE(log1->hasLevelOverridden());
   EXPECT_TRUE(log2->level() == Level::ERROR);  // *own
-  EXPECT_TRUE(log2->hasLevelOverriden());
+  EXPECT_TRUE(log2->hasLevelOverridden());
 
   /// @When change level of loggers
   system_->setLevelOfGroup("group1", Level::CRITICAL);
@@ -989,9 +984,9 @@ TEST_F(LoggingSystemTest, ChangeLevelOfLogger) {
   //           ^     ^
 
   EXPECT_TRUE(log1->level() == Level::CRITICAL);  // *g1
-  EXPECT_FALSE(log1->hasLevelOverriden());
+  EXPECT_FALSE(log1->hasLevelOverridden());
   EXPECT_TRUE(log2->level() == Level::CRITICAL);  // *g1
-  EXPECT_FALSE(log2->hasLevelOverriden());
+  EXPECT_FALSE(log2->hasLevelOverridden());
 }
 
 TEST_F(LoggingSystemTest, ChangeSinkOfLogger) {
@@ -1041,9 +1036,9 @@ TEST_F(LoggingSystemTest, ChangeSinkOfLogger) {
   //  Level:   @1=S1  S2
 
   EXPECT_TRUE(log1->sink() == sink1);  // g1
-  EXPECT_FALSE(log1->hasSinkOverriden());
+  EXPECT_FALSE(log1->hasSinkOverridden());
   EXPECT_TRUE(log2->sink() == sink2);  // own
-  EXPECT_TRUE(log2->hasSinkOverriden());
+  EXPECT_TRUE(log2->hasSinkOverridden());
 
   /// @When change sink of loggers
   system_->setSinkOfLogger("Log1", "sink3");
@@ -1056,9 +1051,9 @@ TEST_F(LoggingSystemTest, ChangeSinkOfLogger) {
   //           ^     ^
 
   EXPECT_TRUE(log1->sink() == sink3);  // *own
-  EXPECT_TRUE(log1->hasSinkOverriden());
+  EXPECT_TRUE(log1->hasSinkOverridden());
   EXPECT_TRUE(log2->sink() == sink4);  // *own
-  EXPECT_TRUE(log2->hasSinkOverriden());
+  EXPECT_TRUE(log2->hasSinkOverridden());
 
   /// @When change sink of loggers
   system_->setSinkOfGroup("group1", "sink5");
@@ -1080,9 +1075,9 @@ TEST_F(LoggingSystemTest, ChangeSinkOfLogger) {
   //           ^     ^
 
   EXPECT_TRUE(log1->sink() == sink5);  // *g1
-  EXPECT_FALSE(log1->hasSinkOverriden());
+  EXPECT_FALSE(log1->hasSinkOverridden());
   EXPECT_TRUE(log2->sink() == sink5);  // *g1
-  EXPECT_FALSE(log2->hasSinkOverriden());
+  EXPECT_FALSE(log2->hasSinkOverridden());
 }
 
 TEST_F(LoggingSystemTest, ChangeGroupOfLogger) {
@@ -1132,15 +1127,15 @@ TEST_F(LoggingSystemTest, ChangeGroupOfLogger) {
 
   EXPECT_TRUE(log1->group() == group1);
   EXPECT_TRUE(log1->sink() == sink1);
-  EXPECT_FALSE(log1->hasSinkOverriden());
+  EXPECT_FALSE(log1->hasSinkOverridden());
   EXPECT_TRUE(log1->level() == Level::TRACE);
-  EXPECT_FALSE(log1->hasLevelOverriden());
+  EXPECT_FALSE(log1->hasLevelOverridden());
 
   EXPECT_TRUE(log2->group() == group1);
   EXPECT_TRUE(log2->sink() == sink3);
-  EXPECT_TRUE(log2->hasSinkOverriden());
+  EXPECT_TRUE(log2->hasSinkOverridden());
   EXPECT_TRUE(log2->level() == Level::CRITICAL);
-  EXPECT_TRUE(log2->hasLevelOverriden());
+  EXPECT_TRUE(log2->hasLevelOverridden());
 
   /// @When change group of loggers
   system_->setGroupOfLogger("Log1", "second");
@@ -1155,13 +1150,13 @@ TEST_F(LoggingSystemTest, ChangeGroupOfLogger) {
 
   EXPECT_TRUE(log1->group() == group2);
   EXPECT_TRUE(log1->sink() == sink2);
-  EXPECT_FALSE(log1->hasSinkOverriden());
+  EXPECT_FALSE(log1->hasSinkOverridden());
   EXPECT_TRUE(log1->level() == Level::DEBUG);
-  EXPECT_FALSE(log1->hasLevelOverriden());
+  EXPECT_FALSE(log1->hasLevelOverridden());
 
   EXPECT_TRUE(log2->group() == group2);
   EXPECT_TRUE(log2->sink() == sink3);
-  EXPECT_TRUE(log2->hasSinkOverriden());
+  EXPECT_TRUE(log2->hasSinkOverridden());
   EXPECT_TRUE(log2->level() == Level::CRITICAL);
-  EXPECT_TRUE(log2->hasLevelOverriden());
+  EXPECT_TRUE(log2->hasLevelOverridden());
 }


### PR DESCRIPTION
Before parentless group properties has marked overridden, and have not been changing at setting parent group. This PR fix it.