### PR TITLE
Fix typo in function(fatal_error)

### DIFF
--- a/.github/aux/clang-tidy.sh
+++ b/.github/aux/clang-tidy.sh
@@ -23,7 +23,7 @@ cd $(dirname $0)/..
 FILES=$(get_files)
 
 CLANG_TIDY=$(which clang-tidy)
-RUN_CLANG_TIDY=$(which run-clang-tidy.py)
+RUN_CLANG_TIDY=$(which run-clang-tidy)
 
 # filter compile_commands.json
 echo ${FILES} | python3 ./aux/filter_compile_commands.py -p ${BUILD_DIR}

--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -3,7 +3,7 @@ function(print)
 endfunction()
 
 function(fatal_error)
-    message(FATAL_ERROOR "[${CMAKE_PROJECT_NAME}] ${ARGV}")
+    message(FATAL_ERROR "[${CMAKE_PROJECT_NAME}] ${ARGV}")
 endfunction()
 
 function(add_cache_flag var_name flag)

--- a/cmake/toolchain/compiler.cmake
+++ b/cmake/toolchain/compiler.cmake
@@ -1,4 +1,4 @@
-if (CMAKE_CXX_COMPILER_ID STREQUAL "^(AppleClang|Clang)$")
+if (CMAKE_CXX_COMPILER_ID MATCHES "^(AppleClang|Clang)$")
     print("Using Clang")
     include(${CMAKE_CURRENT_LIST_DIR}/compiler/clang.cmake)
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")

--- a/cmake/toolchain/compiler.cmake
+++ b/cmake/toolchain/compiler.cmake
@@ -1,4 +1,4 @@
-if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+if (CMAKE_CXX_COMPILER_ID STREQUAL "^(AppleClang|Clang)$")
     print("Using Clang")
     include(${CMAKE_CURRENT_LIST_DIR}/compiler/clang.cmake)
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")


### PR DESCRIPTION
Beware that I noticed this typo when received a message "FATAL ERROOR: Apple Clang is not supported", so this perhaps has to be fixed before fixing the typo.
Here, I suppose: https://github.com/soramitsu/soralog/blob/master/cmake/toolchain/compiler.cmake