### PR TITLE
Fix missing dependency

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,6 +82,7 @@ add_library(logging_system
     )
 target_link_libraries(logging_system
     sink
+    sink_to_nowhere
     )
 
 add_library(soralog soralog.cpp)


### PR DESCRIPTION
Caused link errors in https://github.com/soramitsu/kagome/pull/1228

```
/usr/bin/ld: /github/home/.hunter/_Base/20b55e7/9af12a1/4cb8d1a/Install/lib/soralog/liblogging_systemd.a(logging_system.cpp.o): in function `void __gnu_cxx::new_allocator<soralog::SinkToNowhere>::construct<soralog::SinkToNowhere, char const (&) [2]>(soralog::SinkToNowhere*, char const (&) [2])':
/usr/include/c++/9/ext/new_allocator.h:146: undefined reference to `soralog::SinkToNowhere::SinkToNowhere(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)'
/usr/bin/ld: /github/home/.hunter/_Base/20b55e7/9af12a1/4cb8d1a/Install/lib/soralog/liblogging_systemd.a(logging_system.cpp.o): in function `void __gnu_cxx::new_allocator<soralog::SinkToNowhere>::destroy<soralog::SinkToNowhere>(soralog::SinkToNowhere*)':
/usr/include/c++/9/ext/new_allocator.h:152: undefined reference to `soralog::SinkToNowhere::~SinkToNowhere()'
collect2: error: ld returned 1 exit status
```