### PR TITLE
Fix for newer clang build

### DIFF
--- a/src/logging_system.cpp
+++ b/src/logging_system.cpp
@@ -6,6 +6,7 @@
 #include <soralog/logging_system.hpp>
 
 #include <cassert>
+#include <functional>
 #include <iostream>
 #include <set>
 


### PR DESCRIPTION
Related issue: #23

There was a bug with broken build on clang-13+ compilers.
As a fix I added required #include 
