### PR TITLE
truncated message warning

### DIFF
--- a/include/soralog/event.hpp
+++ b/include/soralog/event.hpp
@@ -133,8 +133,8 @@ namespace soralog {
       }
 
       UNLIKELY_IF(message_size_ > max_message_length) {
-        std::string_view warning =
-            " !!! message truncated, set max_message_length: ";
+        constexpr std::string_view warning =
+            " <<< truncated; original length: ";
         auto warning_size =
             warning.size()
             + ::fmt::detail::count_digits(static_cast<uint64_t>(message_size_));

--- a/include/soralog/event.hpp
+++ b/include/soralog/event.hpp
@@ -138,8 +138,9 @@ namespace soralog {
         const auto warning_size =
             warning.size()
             + ::fmt::detail::count_digits(static_cast<uint64_t>(message_size_));
-        LIKELY_IF(max_message_length >= warning_size)
-        it.pos += max_message_length - warning_size;
+        LIKELY_IF(max_message_length >= warning_size) {
+          it.pos += max_message_length - warning_size;
+        }
         ::fmt::format_to_n(it, warning_size, "{}{}", warning, message_size_);
       }
 

--- a/include/soralog/event.hpp
+++ b/include/soralog/event.hpp
@@ -135,20 +135,12 @@ namespace soralog {
       UNLIKELY_IF(message_size_ > max_message_length) {
         constexpr std::string_view warning =
             " <<< truncated; original length: ";
-        auto warning_size =
+        const auto warning_size =
             warning.size()
             + ::fmt::detail::count_digits(static_cast<uint64_t>(message_size_));
-        UNLIKELY_IF(warning_size > max_message_length) {
-          message_size_ = ::fmt::format_to_n(it,
-                                             max_message_length,
-                                             "max_message_length: {}",
-                                             message_size_)
-                              .size;
-        }
-        else {
-          it.pos += max_message_length - warning_size;
-          ::fmt::format_to_n(it, warning_size, "{}{}", warning, message_size_);
-        }
+        LIKELY_IF(max_message_length >= warning_size)
+        it.pos += max_message_length - warning_size;
+        ::fmt::format_to_n(it, warning_size, "{}{}", warning, message_size_);
       }
 
       // Ensure message does not exceed allowed length

--- a/include/soralog/likely.hpp
+++ b/include/soralog/likely.hpp
@@ -1,0 +1,28 @@
+/**
+ * Copyright Soramitsu Co., 2021-2023
+ * Copyright Quadrivium Co., 2023
+ * All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#if not defined(LIKELY_IF)
+#if __cplusplus >= 202002L
+#define LIKELY_IF(x) [[likely]] if (x)
+#elif defined(__has_builtin) and __has_builtin(__builtin_expect)
+#define LIKELY_IF(x) if (__builtin_expect((x), 1))
+#else
+#define LIKELY_IF(x) if (x)
+#endif
+#endif
+
+#if not defined(UNLIKELY_IF)
+#if __cplusplus >= 202002L
+#define UNLIKELY_IF(x) [[unlikely]] if (x)
+#elif defined(__has_builtin) and __has_builtin(__builtin_expect)
+#define UNLIKELY_IF(x) if (__builtin_expect((x), 0))
+#else
+#define UNLIKELY_IF(x) if (x)
+#endif
+#endif

--- a/include/soralog/likely.hpp
+++ b/include/soralog/likely.hpp
@@ -7,21 +7,29 @@
 
 #pragma once
 
-#if not defined(LIKELY_IF)
+#ifndef LIKELY_IF
 #if __cplusplus >= 202002L
-#define LIKELY_IF(x) [[likely]] if (x)
-#elif defined(__has_builtin) and __has_builtin(__builtin_expect)
-#define LIKELY_IF(x) if (__builtin_expect((x), 1))
+#define LIKELY_IF(x) if (x) [[likely]]
+#elif defined(__has_builtin)
+#if __has_builtin(__builtin_expect)
+#define LIKELY_IF(x) if (__builtin_expect(!!(x), 1))
+#else
+#define LIKELY_IF(x) if (x)
+#endif
 #else
 #define LIKELY_IF(x) if (x)
 #endif
 #endif
 
-#if not defined(UNLIKELY_IF)
+#ifndef UNLIKELY_IF
 #if __cplusplus >= 202002L
-#define UNLIKELY_IF(x) [[unlikely]] if (x)
-#elif defined(__has_builtin) and __has_builtin(__builtin_expect)
-#define UNLIKELY_IF(x) if (__builtin_expect((x), 0))
+#define UNLIKELY_IF(x) if (x) [[unlikely]]
+#elif defined(__has_builtin)
+#if __has_builtin(__builtin_expect)
+#define UNLIKELY_IF(x) if (__builtin_expect(!!(x), 0))
+#else
+#define UNLIKELY_IF(x) if (x)
+#endif
 #else
 #define UNLIKELY_IF(x) if (x)
 #endif

--- a/include/soralog/sink.hpp
+++ b/include/soralog/sink.hpp
@@ -15,25 +15,12 @@
 
 #include <soralog/circular_buffer.hpp>
 #include <soralog/event.hpp>
+#include <soralog/likely.hpp>
 
 #ifdef NDEBUG
 #define IF_RELEASE true
 #else
 #define IF_RELEASE false
-#endif
-
-#if not defined(LIKELY_IF)
-#if __cplusplus >= 202002L
-#define LIKELY_IF(x) [[likely]] if (x)
-#elif defined(__has_builtin)
-#if __has_builtin(__builtin_expect)
-#define LIKELY_IF(x) if (__builtin_expect((x), 1))
-#else
-#define LIKELY_IF(x) if (x)
-#endif
-#else
-#define LIKELY_IF(x) if (x)
-#endif
 #endif
 
 namespace soralog {


### PR DESCRIPTION
- When message doesn't fit buffer, replace part of message with "message truncated" warning, suggesting `max_message_length` yaml config.
  - Discuss and choose warning message text and format during review